### PR TITLE
[Fix] 게시글 검색 버그 수정, 게시글 상세조회 응답 memberid 삭제

### DIFF
--- a/src/main/java/com/palbang/unsemawang/community/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/palbang/unsemawang/community/dto/response/PostDetailResponse.java
@@ -20,8 +20,8 @@ public class PostDetailResponse {
 	@Schema(description = "게시글 ID", required = true, example = "1")
 	private Long id;
 
-	@Schema(description = "작성자 ID", required = true, example = "UUID")
-	private String memberId;
+	// @Schema(description = "작성자 ID", required = true, example = "UUID")
+	// private String memberId;
 
 	@Schema(description = "게시글 제목", required = true, example = "게시글 제목")
 	private String title;

--- a/src/main/java/com/palbang/unsemawang/community/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/com/palbang/unsemawang/community/repository/PostRepositoryCustomImpl.java
@@ -197,10 +197,9 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
 
 	private BooleanExpression buildSearchCondition(String keyword, String searchType) {
 		if ("all".equals(searchType)) {
-			return post.isAnonymous.isFalse() // 익명 글 제외 조건 추가
-				.and(post.title.containsIgnoreCase(keyword)
-					.or(post.content.containsIgnoreCase(keyword))
-					.or(post.member.nickname.containsIgnoreCase(keyword)));
+			return post.title.containsIgnoreCase(keyword)
+				.or(post.content.containsIgnoreCase(keyword))
+				.or(post.member.nickname.containsIgnoreCase(keyword).and(post.isAnonymous.isFalse()));
 		} else if ("title".equals(searchType)) {
 			return post.title.containsIgnoreCase(keyword);
 		} else if ("content".equals(searchType)) {

--- a/src/main/java/com/palbang/unsemawang/community/service/PostDetailService.java
+++ b/src/main/java/com/palbang/unsemawang/community/service/PostDetailService.java
@@ -61,7 +61,7 @@ public class PostDetailService {
 		boolean isMyPost) {
 		return PostDetailResponse.builder()
 			.id(post.getId())
-			.memberId(post.getMember().getId())
+			// .memberId(post.getMember().getId())
 			.title(post.getTitle())
 			.content(post.getContent())
 			.nickname(post.getIsAnonymous() ? "익명" : post.getMember().getNickname())


### PR DESCRIPTION
# 🚀 Pull Request

Fix: 게시글 검색 버그 수정, 게시글 상세조회 응답 memberid 삭제

## 📋 작업 내용

1. `PostRepositoryCustomImpl` 의 게시글 검색(`buildSearchCondition`) 수정
2. `PostDetailResponse`의 `memberId` 필드 삭제

## 🔧 변경된 코드 설명

1. `PostRepositoryCustomImpl` 의 게시글 검색(`buildSearchCondition`) 수정
 - 기존 코드의 익명 글 제외 조건이 모든 익명게시글을 제외
 - 작성자가 '익명'인 경우만 제외하도록 수정

2. `PostDetailResponse`의 `memberId` 필드 삭제
 - 게시글 상세조회 시 익명인 경우에도 `memberId` 필드가 노출되어 삭제함


## ✅ 테스트 여부

- [x] 테스트 코드 실행 여부
- [x] 서버 실행 여부
- [x] 스웨거 테스트 여부

## 👽 비고

기타 알림 사항이 있으면 적어주세요.
