### PR TITLE
[Fix] 미래의 생년월일 회원가입 안되도록 검증 로직 추가 #216

### DIFF
--- a/src/main/java/com/palbang/unsemawang/member/controller/MemberController.java
+++ b/src/main/java/com/palbang/unsemawang/member/controller/MemberController.java
@@ -14,7 +14,7 @@ import com.palbang.unsemawang.common.constants.ResponseCode;
 import com.palbang.unsemawang.common.exception.GeneralException;
 import com.palbang.unsemawang.common.response.ErrorResponse;
 import com.palbang.unsemawang.common.response.Response;
-import com.palbang.unsemawang.common.util.file.service.FileServiceImpl;
+import com.palbang.unsemawang.common.util.file.service.FileService;
 import com.palbang.unsemawang.fortune.dto.request.FortuneInfoRegisterRequest;
 import com.palbang.unsemawang.fortune.service.FortuneUserInfoRegisterService;
 import com.palbang.unsemawang.fortune.service.FortuneUserInfoUpdateService;
@@ -44,7 +44,7 @@ import lombok.extern.slf4j.Slf4j;
 public class MemberController {
 	private final MemberService memberService;
 	private final FortuneUserInfoRegisterService fortuneInfoRegisterService;
-	private final FileServiceImpl fileService;
+	private final FileService fileService;
 	private final FortuneUserInfoUpdateService fortuneUserInfoUpdateService;
 
 	@Operation(

--- a/src/main/java/com/palbang/unsemawang/member/dto/SignupExtraInfoRequest.java
+++ b/src/main/java/com/palbang/unsemawang/member/dto/SignupExtraInfoRequest.java
@@ -1,5 +1,6 @@
 package com.palbang.unsemawang.member.dto;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -15,7 +16,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Builder
 @Getter
 @NoArgsConstructor
@@ -93,6 +96,18 @@ public class SignupExtraInfoRequest {
 
 		// 일수가 유효한 범위에 있는지 확인
 		return this.day >= 1 && this.day <= daysInMonth[this.month - 1];
+	}
+
+	@AssertTrue(message = "올바른 생년월일을 입력해주세요")
+	private boolean isValidBirthday() {
+		LocalDate currentDate = LocalDate.now();
+		LocalDate birthday = LocalDate.of(year, month, day);
+
+		if (currentDate.isBefore(birthday)) {
+			return false;
+		}
+
+		return true;
 	}
 
 	public void updateMemberId(String id) {

--- a/src/main/java/com/palbang/unsemawang/member/dto/SignupExtraInfoRequest.java
+++ b/src/main/java/com/palbang/unsemawang/member/dto/SignupExtraInfoRequest.java
@@ -16,9 +16,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Builder
 @Getter
 @NoArgsConstructor

--- a/src/test/java/com/palbang/unsemawang/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/palbang/unsemawang/member/controller/MemberControllerTest.java
@@ -1,0 +1,94 @@
+package com.palbang.unsemawang.member.controller;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.palbang.unsemawang.WithCustomMockUser;
+import com.palbang.unsemawang.common.util.file.service.FileService;
+import com.palbang.unsemawang.fortune.service.FortuneUserInfoRegisterService;
+import com.palbang.unsemawang.fortune.service.FortuneUserInfoUpdateService;
+import com.palbang.unsemawang.member.dto.SignupExtraInfoRequest;
+import com.palbang.unsemawang.member.service.MemberService;
+
+@WebMvcTest(controllers = MemberController.class)
+@WithCustomMockUser
+class MemberControllerTest {
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private MemberService memberService;
+
+	@MockBean
+	private FortuneUserInfoRegisterService fortuneUserInfoRegisterService;
+
+	@MockBean
+	private FortuneUserInfoUpdateService fortuneUserInfoUpdateService;
+
+	@MockBean
+	private FileService fileService;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Test
+	@DisplayName(value = "추가정보 입력 - 오늘 날짜의 생년월일로 회원가입할 경우 성공")
+	public void todayDate_signup() throws Exception {
+		// given
+		SignupExtraInfoRequest request = SignupExtraInfoRequest.builder()
+			.nickname("testnick")
+			.sex('여')
+			.year(LocalDate.now().getYear())
+			.month(LocalDate.now().getMonthValue())
+			.day(LocalDate.now().getDayOfMonth())
+			.hour(2)
+			.solunar("lunar")
+			.youn(1)
+			.build();
+
+		// when, then
+		mockMvc.perform(post("/member/signup/extra-info")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request))
+				.with(csrf())
+			)
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	@DisplayName(value = "추가정보 입력 - 내일 날짜의 생년월일로 회원가입할 경우 실패")
+	public void tomorrowDate_signup() throws Exception {
+		// given
+		SignupExtraInfoRequest request = SignupExtraInfoRequest.builder()
+			.nickname("testnick")
+			.sex('여')
+			.year(LocalDate.now().plusDays(1).getYear())
+			.month(LocalDate.now().plusDays(1).getMonthValue())
+			.day(LocalDate.now().plusDays(1).getDayOfMonth())
+			.hour(2)
+			.solunar("lunar")
+			.youn(1)
+			.build();
+
+		// when, then
+		mockMvc.perform(post("/member/signup/extra-info")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request))
+				.with(csrf())
+			)
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message").value("올바른 생년월일을 입력해주세요"));
+	}
+}


### PR DESCRIPTION
# 🚀 Pull Request

**미래의 생년월일 회원가입 안되도록 검증 로직 추가**

## #️⃣ 연관된 이슈

- Closed #216 

## 📋 작업 내용

- `SignupExtraInfoRequest`에 생년월일이 오늘 이후의 날짜일 경우 예외 처리하도록 검증 로직 추가(`isValidBirthday`메서드)
- 오늘 날짜로 회원 가입을 할 경우(성공), 내일 날짜로 회원 가입을 할 경우(실패)를 나눠 테스트 코드 진행

## 🔧 변경된 코드 설명

- `MemberController`가 FileService 인터페이스가 아닌 구현체를 참조하고 있어 해당 부분을 수정 하였습니다
	`private final FileServiceImpl fileService;` -> `private final FileService fileService;`

## ✅ 테스트 여부

- [x] 테스트 코드 실행 여부
- [ ] 서버 실행 여부
- [ ] 스웨거 테스트 여부

## 👽 비고

.
