### PR TITLE
[Feature] 사주 정보 저장 및 수정 시 일주 정보 갱신  #219

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ ext {
 
 repositories {
     mavenCentral()
+    maven { url 'https://jitpack.io' }
 }
 
 dependencies {
@@ -94,6 +95,8 @@ dependencies {
     // Apache 5.2
     implementation 'org.apache.httpcomponents.client5:httpclient5:5.2'
     implementation 'org.apache.httpcomponents.core5:httpcore5:5.2'
+
+    implementation 'com.github.usingsky:KoreanLunarCalendar:0.3.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/palbang/unsemawang/common/util/saju/SajuCalculator.java
+++ b/src/main/java/com/palbang/unsemawang/common/util/saju/SajuCalculator.java
@@ -3,19 +3,39 @@ package com.palbang.unsemawang.common.util.saju;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 
+import com.github.usingsky.calendar.KoreanLunarCalendar;
+
 public class SajuCalculator {
 
 	// 천간 (10)과 지지 (12)
 	private static final String[] HEAVENLY_STEMS = {"갑", "을", "병", "정", "무", "기", "경", "신", "임", "계"};
 	private static final String[] EARTHLY_BRANCHES = {"자", "축", "인", "묘", "진", "사", "오", "미", "신", "유", "술", "해"};
 
-	// 일주(日柱) 계산 (1900년 1월 1일을 기준으로 계산)
-	public static String getDayGanZhi(int year, int month, int day) {
-		LocalDate baseDate = LocalDate.of(1900, 1, 1);
-		LocalDate targetDate = LocalDate.of(year, month, day);
-		long daysPassed = ChronoUnit.DAYS.between(baseDate, targetDate);
-		String stem = HEAVENLY_STEMS[(int)(daysPassed % 10)];
-		String branch = EARTHLY_BRANCHES[(int)((daysPassed - 2) % 12)];
-		return stem + branch;
+	private static final LocalDate BASE_DATE = LocalDate.of(1900, 1, 1);
+
+	public static String getDayGan(LocalDate targetDate) {
+
+		long daysPassed = ChronoUnit.DAYS.between(BASE_DATE, targetDate);
+
+		return HEAVENLY_STEMS[(int)(daysPassed % 10)];
 	}
+
+	public static String getDayZhi(LocalDate targetDate) {
+
+		long daysPassed = ChronoUnit.DAYS.between(BASE_DATE, targetDate);
+
+		return EARTHLY_BRANCHES[(int)((daysPassed - 2) % 12)];
+	}
+
+	public static LocalDate getSolarDate(int year, int month, int day, boolean isLunar, boolean isIntercalation) {
+		if (isLunar) {
+			KoreanLunarCalendar calendar = KoreanLunarCalendar.getInstance();
+			calendar.setLunarDate(year, month, day, isIntercalation);
+			year = calendar.getSolarYear();
+			month = calendar.getSolarMonth();
+			day = calendar.getSolarDay();
+		}
+		return LocalDate.of(year, month, day);
+	}
+
 }

--- a/src/main/java/com/palbang/unsemawang/common/util/saju/SajuCalculator.java
+++ b/src/main/java/com/palbang/unsemawang/common/util/saju/SajuCalculator.java
@@ -1,0 +1,21 @@
+package com.palbang.unsemawang.common.util.saju;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+public class SajuCalculator {
+
+	// 천간 (10)과 지지 (12)
+	private static final String[] HEAVENLY_STEMS = {"갑", "을", "병", "정", "무", "기", "경", "신", "임", "계"};
+	private static final String[] EARTHLY_BRANCHES = {"자", "축", "인", "묘", "진", "사", "오", "미", "신", "유", "술", "해"};
+
+	// 일주(日柱) 계산 (1900년 1월 1일을 기준으로 계산)
+	public static String getDayGanZhi(int year, int month, int day) {
+		LocalDate baseDate = LocalDate.of(1900, 1, 1);
+		LocalDate targetDate = LocalDate.of(year, month, day);
+		long daysPassed = ChronoUnit.DAYS.between(baseDate, targetDate);
+		String stem = HEAVENLY_STEMS[(int)(daysPassed % 10)];
+		String branch = EARTHLY_BRANCHES[(int)((daysPassed - 2) % 12)];
+		return stem + branch;
+	}
+}

--- a/src/main/java/com/palbang/unsemawang/fortune/entity/FortuneUserInfo.java
+++ b/src/main/java/com/palbang/unsemawang/fortune/entity/FortuneUserInfo.java
@@ -1,8 +1,10 @@
 package com.palbang.unsemawang.fortune.entity;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import com.palbang.unsemawang.common.entity.BaseEntity;
+import com.palbang.unsemawang.common.util.saju.SajuCalculator;
 import com.palbang.unsemawang.member.entity.Member;
 
 import jakarta.persistence.Column;
@@ -61,6 +63,12 @@ public class FortuneUserInfo extends BaseEntity {
 	@Column(name = "solunar", nullable = false)
 	private String solunar;
 
+	@Column(name = "day_gan")
+	private String dayGan;
+
+	@Column(name = "day_zhi")
+	private String dayZhi;
+
 	@Column(name = "registered_at", nullable = false, updatable = false)
 	@Builder.Default
 	private LocalDateTime registeredAt = LocalDateTime.now(); // 생성일시
@@ -104,8 +112,18 @@ public class FortuneUserInfo extends BaseEntity {
 		this.updatedAt = LocalDateTime.now(); // 수정 시간 갱신
 	}
 
-	public void updateFortuneNickname(String nickname){
+	public void updateFortuneNickname(String nickname) {
 		this.nickname = nickname;
 		this.updatedAt = LocalDateTime.now(); // 수정 시간 갱신
+	}
+
+	public void updateDayGanZhiFromBirthday() {
+		boolean isLunar = solunar.equals("lunar");
+		boolean isIntercalation = youn == 1;
+
+		LocalDate lunarBirthday = SajuCalculator.getSolarDate(year, month, day, isLunar, isIntercalation);
+
+		this.dayGan = SajuCalculator.getDayGan(lunarBirthday);
+		this.dayZhi = SajuCalculator.getDayZhi(lunarBirthday);
 	}
 }

--- a/src/main/java/com/palbang/unsemawang/fortune/service/FortuneUserInfoRegisterService.java
+++ b/src/main/java/com/palbang/unsemawang/fortune/service/FortuneUserInfoRegisterService.java
@@ -58,6 +58,9 @@ public class FortuneUserInfoRegisterService {
 			.updatedAt(LocalDateTime.now())
 			.build();
 
+		// 일주 정보 갱신
+		fortuneUserInfo.updateDayGanZhiFromBirthday();
+
 		// 5. 데이터 저장
 		fortuneUserInfoRepository.save(fortuneUserInfo);
 

--- a/src/main/java/com/palbang/unsemawang/fortune/service/FortuneUserInfoUpdateService.java
+++ b/src/main/java/com/palbang/unsemawang/fortune/service/FortuneUserInfoUpdateService.java
@@ -50,6 +50,10 @@ public class FortuneUserInfoUpdateService {
 			req.getYoun(),
 			req.getSolunar()
 		);
+
+		// 일주 정보 갱신
+		fortuneUserInfo.updateDayGanZhiFromBirthday();
+
 		fortuneUserInfoRepository.save(fortuneUserInfo);
 
 		// 4. 응답 생성
@@ -65,8 +69,9 @@ public class FortuneUserInfoUpdateService {
 			.solunar(fortuneUserInfo.getSolunar())
 			.build();
 	}
+
 	public void updateFortuneUserNickname(String id, String nickname) {
-		List<FortuneUserInfo> fortuneUserInfoList = fortuneUserInfoRepository.findByMemberIdAndRelation(id,"본인");
+		List<FortuneUserInfo> fortuneUserInfoList = fortuneUserInfoRepository.findByMemberIdAndRelation(id, "본인");
 
 		if (fortuneUserInfoList.isEmpty()) {
 			throw new GeneralException(ResponseCode.ERROR_SEARCH, "해당 회원의 본인 사주정보를 찾지 못했습니다.");


### PR DESCRIPTION
# 🚀 Pull Request

**사주 정보 저장 및 수정 시 일주 정보 갱신**

## #️⃣ 연관된 이슈

- #219 

## 📋 작업 내용

사주 정보 저장 및 수정 시 일간/일지를 계산해 저장하는 로직 추가

(추가 설명) 
- 양/음력 변환을 위해 KoreanLunarCalendar 라이브러리에 대한 의존성을 추가하였습니다
- `SajuCalcurator` 클래스 추가 - 오행 정보를 계산하기 위한 클래스로, 현재는 일간/일지를 계산하는 메서드와 음력 날짜를 양력으로 변환하는 메서드를 구현해 놓은 상태입니다
- `FortunUserInfo` 엔티티에 `updateDayGanZhiFromBirthday()` 메서드 추가 - SajuCalcurator에서 제공하는 메서드를 통해 일간 및 일지 필드 값을 변경하는 메서드입니다

## 🔧 변경된 코드 설명

.

## ✅ 테스트 여부

- [x] 테스트 코드 실행 여부
- [x] 서버 실행 여부
- [x] 스웨거 테스트 여부

## 👽 비고

 - 추후에 음력 날짜를 양력으로 변환하는 메서드를 별도 클래스로 분리하겠습니다
 - 오행 관련 enum 타입이 업로드 되는 대로 해당 타입을 일주/일지 계산 메서드의 반환 타입으로 변경할 예정입니다