### PR TITLE
[Fix] 사주 정보 CUD 검증 추가 #221

### DIFF
--- a/src/main/java/com/palbang/unsemawang/common/constants/ResponseCode.java
+++ b/src/main/java/com/palbang/unsemawang/common/constants/ResponseCode.java
@@ -60,6 +60,9 @@ public enum ResponseCode implements Codable {
 	ALREADY_REGISTERED_MEMBER("6130", HttpStatus.CONFLICT, "이미 가입된 회원입니다"),
 	NOT_ADD_SELF_RELATION("6131", HttpStatus.BAD_REQUEST, "본인 사주는 추가 할 수 없습니다."),
 	NOT_DELETE_SELF_RELATION("6132", HttpStatus.BAD_REQUEST, "본인 사주는 삭제 할 수 없습니다."),
+	NOT_EXIST_FORTUNE_USER_INFO("6133", HttpStatus.BAD_REQUEST, "해당 사주 정보를 찾을 수 없습니다."),
+	NOT_EXIST_USER_RELATION("6134", HttpStatus.BAD_REQUEST, "해당 사주 관계를 찾을 수 없습니다."),
+	NOT_CHANGED_RELATION("6135", HttpStatus.BAD_REQUEST, "본인 관계는 수정할 수 없습니다."),
 
 	//  유효성 검사 오류 (형식: 62xx)
 	NOT_LITERAL("6211", HttpStatus.BAD_REQUEST, "문자열 형식이 아님"),

--- a/src/main/java/com/palbang/unsemawang/common/constants/ResponseCode.java
+++ b/src/main/java/com/palbang/unsemawang/common/constants/ResponseCode.java
@@ -58,6 +58,8 @@ public enum ResponseCode implements Codable {
 	NOT_AUTHORIZED_COMMENT_MODIFICATION("6120", HttpStatus.FORBIDDEN, "댓글 수정 권한이 없습니다."),
 	INVALID_CATEGORY("6121", HttpStatus.BAD_REQUEST, "유효하지 않은 카테고리 입니다."),
 	ALREADY_REGISTERED_MEMBER("6130", HttpStatus.CONFLICT, "이미 가입된 회원입니다"),
+	NOT_ADD_SELF_RELATION("6131", HttpStatus.BAD_REQUEST, "본인 사주는 추가 할 수 없습니다."),
+	NOT_DELETE_SELF_RELATION("6132", HttpStatus.BAD_REQUEST, "본인 사주는 삭제 할 수 없습니다."),
 
 	//  유효성 검사 오류 (형식: 62xx)
 	NOT_LITERAL("6211", HttpStatus.BAD_REQUEST, "문자열 형식이 아님"),

--- a/src/main/java/com/palbang/unsemawang/fortune/controller/FortuneUserInfoRegisterController.java
+++ b/src/main/java/com/palbang/unsemawang/fortune/controller/FortuneUserInfoRegisterController.java
@@ -25,7 +25,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/fortune-users")
 @RequiredArgsConstructor
-public class FortuneInfoRegisterController {
+public class FortuneUserInfoRegisterController {
 	private final FortuneUserInfoRegisterService registerService;
 
 	@Operation(

--- a/src/main/java/com/palbang/unsemawang/fortune/repository/FortuneUserInfoRepository.java
+++ b/src/main/java/com/palbang/unsemawang/fortune/repository/FortuneUserInfoRepository.java
@@ -1,6 +1,7 @@
 package com.palbang.unsemawang.fortune.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/palbang/unsemawang/fortune/repository/FortuneUserInfoRepository.java
+++ b/src/main/java/com/palbang/unsemawang/fortune/repository/FortuneUserInfoRepository.java
@@ -19,4 +19,5 @@ public interface FortuneUserInfoRepository extends JpaRepository<FortuneUserInfo
 		"WHERE f.member.id = :id AND r.relationName = :relationName AND f.isDeleted = false")
 	List<FortuneUserInfo> findByMemberIdAndRelation(@Param("id") String id, @Param("relationName") String relationName);
 
+	boolean existsByMemberIdAndRelationId(String memberId, Long relationId);
 }

--- a/src/main/java/com/palbang/unsemawang/fortune/service/FortuneUserInfoDeleteService.java
+++ b/src/main/java/com/palbang/unsemawang/fortune/service/FortuneUserInfoDeleteService.java
@@ -19,15 +19,20 @@ public class FortuneUserInfoDeleteService {
 	private final FortuneUserInfoRepository fortuneUserInfoRepository;
 	private final MemberRepository memberRepository;
 
-	public FortuneUserInfoDeleteResponseDto deleteFortuneUserInfo(String memberId, Long relationId) {
+	public FortuneUserInfoDeleteResponseDto deleteFortuneUserInfo(String memberId, Long fortuneUserInfoId) {
 
 		// 1. Member 조회
 		memberRepository.findById(memberId)
 			.orElseThrow(() -> new GeneralException(ResponseCode.ERROR_SEARCH, "회원을 찾지 못했습니다."));
 
 		// 2. 사주 정보 조회
-		FortuneUserInfo fortuneUserInfo = fortuneUserInfoRepository.findById(relationId)
+		FortuneUserInfo fortuneUserInfo = fortuneUserInfoRepository.findById(fortuneUserInfoId)
 			.orElseThrow(() -> new GeneralException(ResponseCode.ERROR_SEARCH, "해당 사주 정보를 찾지 못했습니다."));
+
+		// 본인 사주 정보이면 삭제 불가
+		if (fortuneUserInfo.getRelation().getId() == 1) {
+			throw new GeneralException(ResponseCode.NOT_DELETE_SELF_RELATION);
+		}
 
 		// 조회된 fortuneUserInfo의 idDeleted가 false면 true로 바꾸기
 		if (!fortuneUserInfo.getIsDeleted()) {

--- a/src/main/java/com/palbang/unsemawang/fortune/service/FortuneUserInfoRegisterService.java
+++ b/src/main/java/com/palbang/unsemawang/fortune/service/FortuneUserInfoRegisterService.java
@@ -43,9 +43,11 @@ public class FortuneUserInfoRegisterService {
 			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 관계입니다."));
 
 		// relatiionId = 1 (본인)이 이미 있으면 등록 불가
-		boolean existMe = fortuneUserInfoRepository.existsByMemberIdAndRelationId(dto.getMemberId(), 1L);
-		if (relation.getId() == 1 && existMe) {
-			throw new GeneralException(ResponseCode.NOT_ADD_SELF_RELATION);
+		if (relation.getId() == 1) {
+			boolean existMe = fortuneUserInfoRepository.existsByMemberIdAndRelationId(dto.getMemberId(), 1L);
+			if (existMe) {
+				throw new GeneralException(ResponseCode.NOT_ADD_SELF_RELATION);
+			}
 		}
 
 		// 3. FortuneUserInfo 엔티티 생성

--- a/src/main/java/com/palbang/unsemawang/fortune/service/FortuneUserInfoRegisterService.java
+++ b/src/main/java/com/palbang/unsemawang/fortune/service/FortuneUserInfoRegisterService.java
@@ -42,6 +42,12 @@ public class FortuneUserInfoRegisterService {
 		UserRelation relation = userRelationRepository.findByRelationName(dto.getRelationName())
 			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 관계입니다."));
 
+		// relatiionId = 1 (본인)이 이미 있으면 등록 불가
+		boolean existMe = fortuneUserInfoRepository.existsByMemberIdAndRelationId(dto.getMemberId(), 1L);
+		if (relation.getId() == 1 && existMe) {
+			throw new GeneralException(ResponseCode.NOT_ADD_SELF_RELATION);
+		}
+
 		// 3. FortuneUserInfo 엔티티 생성
 		FortuneUserInfo fortuneUserInfo = FortuneUserInfo.builder()
 			.member(member)

--- a/src/main/java/com/palbang/unsemawang/fortune/service/FortuneUserInfoUpdateService.java
+++ b/src/main/java/com/palbang/unsemawang/fortune/service/FortuneUserInfoUpdateService.java
@@ -28,15 +28,20 @@ public class FortuneUserInfoUpdateService {
 	public FortuneUserInfoUpdateResponse updateFortuneUserInfo(FortuneInfoUpdateRequest req) {
 		// Member 조회
 		memberRepository.findById(req.getMemberId())
-			.orElseThrow(() -> new GeneralException(ResponseCode.ERROR_SEARCH, "회원을 찾지 못했습니다."));
+			.orElseThrow(() -> new GeneralException(ResponseCode.NOT_EXIST_MEMBER_ID));
 
 		// 사주 정보 조회
 		FortuneUserInfo fortuneUserInfo = fortuneUserInfoRepository.findById(req.getRelationId())
-			.orElseThrow(() -> new GeneralException(ResponseCode.ERROR_SEARCH, "해당 사주 정보를 찾지 못했습니다."));
+			.orElseThrow(() -> new GeneralException(ResponseCode.NOT_EXIST_FORTUNE_USER_INFO));
 
 		// UserRelation 조회
 		UserRelation userRelation = userRelationRepository.findByRelationName(req.getRelationName())
-			.orElseThrow(() -> new GeneralException(ResponseCode.ERROR_SEARCH, "해당 관계명을 찾을 수 없습니다."));
+			.orElseThrow(() -> new GeneralException(ResponseCode.NOT_EXIST_USER_RELATION));
+
+		// 본인 사주 정보를 수정 할 때, 다른 관계(가족, 지인 등)로 수정할 수 없음
+		if (fortuneUserInfo.getRelation().getId() == 1 && userRelation.getId() != 1) {
+			throw new GeneralException(ResponseCode.NOT_CHANGED_RELATION);
+		}
 
 		// 사주 정보 수정
 		fortuneUserInfo.updateFortuneInfo(

--- a/src/test/java/com/palbang/unsemawang/fortune/controller/FortuneInfoRegisterControllerTest.java
+++ b/src/test/java/com/palbang/unsemawang/fortune/controller/FortuneInfoRegisterControllerTest.java
@@ -21,7 +21,7 @@ import com.palbang.unsemawang.fortune.dto.response.FortuneInfoRegisterResponseDt
 import com.palbang.unsemawang.fortune.service.FortuneUserInfoRegisterService;
 
 @WebMvcTest(
-	controllers = FortuneInfoRegisterController.class
+	controllers = FortuneUserInfoRegisterController.class
 )
 @WithCustomMockUser
 class FortuneInfoRegisterControllerTest {


### PR DESCRIPTION
# 🚀 Pull Request
- 사주 정보 CUD 검증 추가 

## #️⃣ 연관된 이슈
- #221 

## 📋 작업 내용
- "본인" 관계인 사주 정보는 "가족, 지인"등의 관계로 변경할 수 없게 검증을 추가
- 또한 "본인" 관계인 사주정보는 회원당 1개만 존재해야함

## 🔧 변경된 코드 설명
- 검증 추가 로직만 추가

## ✅ 테스트 여부

- [x] 테스트 코드 실행 여부
- [x] 서버 실행 여부
- [x] 스웨거 테스트 여부

## 👽 비고

기타 알림 사항이 있으면 적어주세요.
