### PR TITLE
[Feat] 채팅 추천 5명 조회 #233

### DIFF
--- a/src/main/java/com/palbang/unsemawang/chemistry/constant/FiveElements.java
+++ b/src/main/java/com/palbang/unsemawang/chemistry/constant/FiveElements.java
@@ -37,4 +37,10 @@ public enum FiveElements {
 	public static FiveElements fromReading(String reading) {
 		return lookup.get(reading);
 	}
+
+	// "갑" -> "木" 로 변경
+	public static String convertToChinese(String reading) {
+		FiveElements fe = lookup.get(reading);
+		return fe.chinese;
+	}
 }

--- a/src/main/java/com/palbang/unsemawang/chemistry/controller/RecommendControllerImpl.java
+++ b/src/main/java/com/palbang/unsemawang/chemistry/controller/RecommendControllerImpl.java
@@ -1,6 +1,5 @@
 package com.palbang.unsemawang.chemistry.controller;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
@@ -10,6 +9,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.palbang.unsemawang.chemistry.dto.response.ChemistryRecommendResponse;
+import com.palbang.unsemawang.chemistry.service.RecommendService;
+import com.palbang.unsemawang.chemistry.service.TotalCalculationService;
+import com.palbang.unsemawang.common.constants.ResponseCode;
+import com.palbang.unsemawang.common.exception.GeneralException;
 import com.palbang.unsemawang.oauth2.dto.CustomOAuth2User;
 
 import lombok.RequiredArgsConstructor;
@@ -19,13 +22,22 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class RecommendControllerImpl implements RecommendController {
 
+	private final RecommendService recommendService;
+	private final TotalCalculationService totalCalculationService;
+
 	@GetMapping("/recommendations")
 	@Override
 	public ResponseEntity<List<ChemistryRecommendResponse>> recommendChemistryMember(
-		@AuthenticationPrincipal CustomOAuth2User user
+		@AuthenticationPrincipal CustomOAuth2User auth
 	) {
+		if (auth == null || auth.getId() == null) {
+			throw new GeneralException(ResponseCode.EMPTY_TOKEN);
+		}
 
-		List<ChemistryRecommendResponse> recommendedMemberList = new ArrayList<>();
+		// 모든 사용자에 대한 궁합 점수 DB에 저장
+		totalCalculationService.calculateAndSaveChemistryScores();
+
+		List<ChemistryRecommendResponse> recommendedMemberList = recommendService.getTop5Matches(auth.getId());
 
 		return ResponseEntity.ok(recommendedMemberList);
 	}

--- a/src/main/java/com/palbang/unsemawang/chemistry/dto/MemberWithDayGanDto.java
+++ b/src/main/java/com/palbang/unsemawang/chemistry/dto/MemberWithDayGanDto.java
@@ -1,0 +1,11 @@
+package com.palbang.unsemawang.chemistry.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MemberWithDayGanDto {
+	String memberId;
+	String dayGan;
+}

--- a/src/main/java/com/palbang/unsemawang/chemistry/dto/response/ChemistryRecommendResponse.java
+++ b/src/main/java/com/palbang/unsemawang/chemistry/dto/response/ChemistryRecommendResponse.java
@@ -2,7 +2,9 @@ package com.palbang.unsemawang.chemistry.dto.response;
 
 import java.time.LocalDate;
 
+import com.palbang.unsemawang.chemistry.constant.FiveElements;
 import com.palbang.unsemawang.chemistry.entity.MemberMatchingScore;
+import com.palbang.unsemawang.fortune.entity.FortuneUserInfo;
 import com.palbang.unsemawang.member.entity.Member;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -21,7 +23,7 @@ public class ChemistryRecommendResponse {
 	@Schema(required = true, description = "나와의 궁합 매칭 점수")
 	private Integer score;
 
-	@Schema(required = true, description = "상대방의 오행")
+	@Schema(required = true, description = "상대방의 오행", example = "木")
 	private String fiveElementCn;
 
 	@Schema(required = true, description = "상대방 닉네임")
@@ -40,17 +42,20 @@ public class ChemistryRecommendResponse {
 	private LocalDate lastActiveDate;
 
 	// 점수 스케일링 포함된 정적 팩토리 메서드
-	public static ChemistryRecommendResponse from(MemberMatchingScore scoreEntity, String dayGan, int maxScore) {
+	public static ChemistryRecommendResponse from(MemberMatchingScore scoreEntity, FortuneUserInfo fortuneUserInfo,
+		int maxScore, String imgUrl) {
 		Member matchMember = scoreEntity.getMatchMember();
-		int scaledScore = (int)Math.round(((double)scoreEntity.getScore() / maxScore)) * 100;
+		int scaledScore = (int)Math.round(((double)scoreEntity.getScore() / maxScore) * 10);
+
+		String element = FiveElements.convertToChinese(fortuneUserInfo.getDayGan());
 
 		return ChemistryRecommendResponse.builder()
 			.score(scaledScore)
-			.fiveElementCn(dayGan)
+			.fiveElementCn(element)
 			.nickname(matchMember.getNickname())
-			.profileImageUrl(matchMember.getProfileUrl())
+			.profileImageUrl(imgUrl)
 			.profileBio(matchMember.getDetailBio())
-			.sex(matchMember.getGender())
+			.sex(fortuneUserInfo.getSex())
 			.lastActiveDate(matchMember.getLastLoginAt() != null ? matchMember.getLastLoginAt().toLocalDate() : null)
 			.build();
 	}

--- a/src/main/java/com/palbang/unsemawang/chemistry/dto/response/ChemistryRecommendResponse.java
+++ b/src/main/java/com/palbang/unsemawang/chemistry/dto/response/ChemistryRecommendResponse.java
@@ -2,17 +2,27 @@ package com.palbang.unsemawang.chemistry.dto.response;
 
 import java.time.LocalDate;
 
+import com.palbang.unsemawang.chemistry.entity.MemberMatchingScore;
+import com.palbang.unsemawang.member.entity.Member;
+
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
 public class ChemistryRecommendResponse {
 
 	@Schema(required = true, description = "나와의 궁합 매칭 점수")
 	private Integer score;
 
 	@Schema(required = true, description = "상대방의 오행")
-	private char fiveElementCn;
+	private String fiveElementCn;
 
 	@Schema(required = true, description = "상대방 닉네임")
 	private String nickname;
@@ -28,4 +38,20 @@ public class ChemistryRecommendResponse {
 
 	@Schema(required = false, description = "상대방 마지막 로그인 날짜")
 	private LocalDate lastActiveDate;
+
+	// 점수 스케일링 포함된 정적 팩토리 메서드
+	public static ChemistryRecommendResponse from(MemberMatchingScore scoreEntity, String dayGan, int maxScore) {
+		Member matchMember = scoreEntity.getMatchMember();
+		int scaledScore = (int)Math.round(((double)scoreEntity.getScore() / maxScore)) * 100;
+
+		return ChemistryRecommendResponse.builder()
+			.score(scaledScore)
+			.fiveElementCn(dayGan)
+			.nickname(matchMember.getNickname())
+			.profileImageUrl(matchMember.getProfileUrl())
+			.profileBio(matchMember.getDetailBio())
+			.sex(matchMember.getGender())
+			.lastActiveDate(matchMember.getLastLoginAt() != null ? matchMember.getLastLoginAt().toLocalDate() : null)
+			.build();
+	}
 }

--- a/src/main/java/com/palbang/unsemawang/chemistry/entity/MemberMatchingScore.java
+++ b/src/main/java/com/palbang/unsemawang/chemistry/entity/MemberMatchingScore.java
@@ -31,14 +31,14 @@ public class MemberMatchingScore extends BaseEntity {
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id", nullable = false)
-	private Member memberId;
+	private Member member;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "match_member_id", nullable = false)
-	private Member matchMemberId;
+	private Member matchMember;
 
 	@Column(name = "score", nullable = false)
-	private int score; // 100점 만점
+	private int score;
 
 	@Column(name = "registered_at", updatable = false)
 	@Builder.Default

--- a/src/main/java/com/palbang/unsemawang/chemistry/entity/MemberMatchingScore.java
+++ b/src/main/java/com/palbang/unsemawang/chemistry/entity/MemberMatchingScore.java
@@ -47,4 +47,9 @@ public class MemberMatchingScore extends BaseEntity {
 	@Column(name = "updated_at")
 	@Builder.Default
 	private LocalDateTime updatedAt = LocalDateTime.now();
+
+	public void updateScore(int score) {
+		this.score = score;
+		this.updatedAt = LocalDateTime.now();
+	}
 }

--- a/src/main/java/com/palbang/unsemawang/chemistry/repository/MemberMatchingScore.java
+++ b/src/main/java/com/palbang/unsemawang/chemistry/repository/MemberMatchingScore.java
@@ -1,8 +1,0 @@
-package com.palbang.unsemawang.chemistry.repository;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface MemberMatchingScore extends JpaRepository<MemberMatchingScore, Long> {
-}

--- a/src/main/java/com/palbang/unsemawang/chemistry/repository/MemberMatchingScore.java
+++ b/src/main/java/com/palbang/unsemawang/chemistry/repository/MemberMatchingScore.java
@@ -1,0 +1,8 @@
+package com.palbang.unsemawang.chemistry.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberMatchingScore extends JpaRepository<MemberMatchingScore, Long> {
+}

--- a/src/main/java/com/palbang/unsemawang/chemistry/repository/MemberMatchingScoreRepository.java
+++ b/src/main/java/com/palbang/unsemawang/chemistry/repository/MemberMatchingScoreRepository.java
@@ -6,9 +6,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.palbang.unsemawang.chemistry.entity.MemberMatchingScore;
+import com.palbang.unsemawang.member.entity.Member;
 
 @Repository
 public interface MemberMatchingScoreRepository extends JpaRepository<MemberMatchingScore, Long> {
 
 	List<MemberMatchingScore> findTop5ByMemberIdOrderByScoreDesc(String memberId);
+
+	MemberMatchingScore findByMemberAndMatchMember(Member member, Member matchMember);
 }

--- a/src/main/java/com/palbang/unsemawang/chemistry/repository/MemberMatchingScoreRepository.java
+++ b/src/main/java/com/palbang/unsemawang/chemistry/repository/MemberMatchingScoreRepository.java
@@ -1,0 +1,14 @@
+package com.palbang.unsemawang.chemistry.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.palbang.unsemawang.chemistry.entity.MemberMatchingScore;
+
+@Repository
+public interface MemberMatchingScoreRepository extends JpaRepository<MemberMatchingScore, Long> {
+
+	List<MemberMatchingScore> findTop5ByMemberIdOrderByScoreDesc(String memberId);
+}

--- a/src/main/java/com/palbang/unsemawang/chemistry/service/ChemistryCalculator.java
+++ b/src/main/java/com/palbang/unsemawang/chemistry/service/ChemistryCalculator.java
@@ -1,10 +1,11 @@
-package com.palbang.unsemawang.chemistry.constant;
+package com.palbang.unsemawang.chemistry.service;
 
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import com.palbang.unsemawang.chemistry.constant.FiveElements;
 import com.palbang.unsemawang.common.constants.ResponseCode;
 import com.palbang.unsemawang.common.exception.GeneralException;
 

--- a/src/main/java/com/palbang/unsemawang/chemistry/service/ChemistryCalculator.java
+++ b/src/main/java/com/palbang/unsemawang/chemistry/service/ChemistryCalculator.java
@@ -5,10 +5,13 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.springframework.stereotype.Component;
+
 import com.palbang.unsemawang.chemistry.constant.FiveElements;
 import com.palbang.unsemawang.common.constants.ResponseCode;
 import com.palbang.unsemawang.common.exception.GeneralException;
 
+@Component
 public class ChemistryCalculator {
 	private static final Map<String, Set<String>> good = new HashMap<>(); // 상생 관계
 	private static final Map<String, Set<String>> bad = new HashMap<>(); // 상극 관계

--- a/src/main/java/com/palbang/unsemawang/chemistry/service/RecommendService.java
+++ b/src/main/java/com/palbang/unsemawang/chemistry/service/RecommendService.java
@@ -1,0 +1,56 @@
+package com.palbang.unsemawang.chemistry.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.palbang.unsemawang.chemistry.dto.response.ChemistryRecommendResponse;
+import com.palbang.unsemawang.chemistry.entity.MemberMatchingScore;
+import com.palbang.unsemawang.chemistry.repository.MemberMatchingScoreRepository;
+import com.palbang.unsemawang.common.constants.ResponseCode;
+import com.palbang.unsemawang.common.exception.GeneralException;
+import com.palbang.unsemawang.fortune.repository.FortuneUserInfoRepository;
+import com.palbang.unsemawang.member.entity.Member;
+import com.palbang.unsemawang.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RecommendService {
+	private final MemberMatchingScoreRepository memberMatchingScoreRepository;
+	private final MemberRepository memberRepository;
+	private final FortuneUserInfoRepository fortuneUserInfoRepository;
+
+	@Transactional(readOnly = true)
+	public List<ChemistryRecommendResponse> getTop5Matches(String memberId) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new GeneralException(ResponseCode.NOT_EXIST_MEMBER_ID));
+
+		List<MemberMatchingScore> matchingScores = memberMatchingScoreRepository.findTop5ByMemberIdOrderByScoreDesc(
+			member.getId());
+
+		if (matchingScores.isEmpty()) {
+			throw new GeneralException(ResponseCode.ERROR_SEARCH);
+		}
+
+		// 최대 점수 찾기
+		int maxScore = matchingScores.get(0).getScore(); // 가장 높은 점수 기준으로 스케일링
+		// if (maxScore == 0) {
+		// 	maxScore = 1; // 0 방지 (나누기 오류 방지)
+		// }
+
+		// ✅ 4. 상대방 matchMember.id를 이용해서 FortuneUserInfo에서 오행(dayGan) 가져오기
+		return matchingScores.stream()
+			.map(score -> {
+				String matchMemberId = score.getMatchMember().getId();
+				String dayGan = fortuneUserInfoRepository.findDayGanByMemberId(matchMemberId)
+					.orElseThrow(() -> new GeneralException(ResponseCode.ERROR_SEARCH));
+
+				return ChemistryRecommendResponse.from(score, dayGan, maxScore);
+			})
+			.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/com/palbang/unsemawang/chemistry/service/RecommendService.java
+++ b/src/main/java/com/palbang/unsemawang/chemistry/service/RecommendService.java
@@ -42,8 +42,7 @@ public class RecommendService {
 		// 최대 점수 찾기
 		int maxScore = matchingScores.get(0).getScore(); // 가장 높은 점수 기준으로 스케일링
 		String imgUrl = fileService.getProfileImgUrl(memberId);
-
-		// ✅ 4. 상대방 matchMember.id를 이용해서 FortuneUserInfo에서 오행(dayGan) 가져오기
+		
 		return matchingScores.stream()
 			.map(score -> {
 				String matchMemberId = score.getMatchMember().getId();

--- a/src/main/java/com/palbang/unsemawang/chemistry/service/TotalCalculationService.java
+++ b/src/main/java/com/palbang/unsemawang/chemistry/service/TotalCalculationService.java
@@ -43,15 +43,24 @@ public class TotalCalculationService {
 				int score = ChemistryCalculator.getChemistryScore(baseMemberDto.getDayGan(),
 					targetMemberDto.getDayGan());
 
-				MemberMatchingScore matchingScore = MemberMatchingScore.builder()
-					.member(baseMember)
-					.matchMember(targetMember)
-					.score(score)
-					.build();
+				// 기존 데이터가 있는지 확인
+				MemberMatchingScore existingScore = scoreRepository.findByMemberAndMatchMember(baseMember,
+					targetMember);
 
-				scoreRepository.save(matchingScore);
+				if (existingScore != null) {
+					// 기존 회원 → UPDATE
+					existingScore.updateScore(score);
+					scoreRepository.save(existingScore);
+				} else {
+					// 새로운 회원 → INSERT
+					MemberMatchingScore newScore = MemberMatchingScore.builder()
+						.member(baseMember)
+						.matchMember(targetMember)
+						.score(score)
+						.build();
+					scoreRepository.save(newScore);
+				}
 			}
 		}
 	}
-
 }

--- a/src/main/java/com/palbang/unsemawang/chemistry/service/TotalCalculationService.java
+++ b/src/main/java/com/palbang/unsemawang/chemistry/service/TotalCalculationService.java
@@ -1,0 +1,57 @@
+package com.palbang.unsemawang.chemistry.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.palbang.unsemawang.chemistry.dto.MemberWithDayGanDto;
+import com.palbang.unsemawang.chemistry.entity.MemberMatchingScore;
+import com.palbang.unsemawang.chemistry.repository.MemberMatchingScoreRepository;
+import com.palbang.unsemawang.common.constants.ResponseCode;
+import com.palbang.unsemawang.common.exception.GeneralException;
+import com.palbang.unsemawang.member.entity.Member;
+import com.palbang.unsemawang.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class TotalCalculationService {
+	private final MemberMatchingScoreRepository scoreRepository;
+	private final MemberRepository memberRepository;
+
+	@Transactional
+	public void calculateAndSaveChemistryScores() {
+		List<MemberWithDayGanDto> members = memberRepository.findAllMembersWithDayGan();
+
+		for (int i = 0; i < members.size(); i++) {
+			MemberWithDayGanDto baseMemberDto = members.get(i);
+			Member baseMember = memberRepository.findById(baseMemberDto.getMemberId())
+				.orElseThrow(() -> new GeneralException(ResponseCode.NOT_EXIST_ID));
+
+			for (int j = 0; j < members.size(); j++) {
+				if (i == j) {
+					continue; // 자기 자신과 비교하지 않음
+				}
+
+				MemberWithDayGanDto targetMemberDto = members.get(j);
+				Member targetMember = memberRepository.findById(targetMemberDto.getMemberId())
+					.orElseThrow(() -> new GeneralException(ResponseCode.NOT_EXIST_ID));
+
+				int score = ChemistryCalculator.getChemistryScore(baseMemberDto.getDayGan(),
+					targetMemberDto.getDayGan());
+
+				MemberMatchingScore matchingScore = MemberMatchingScore.builder()
+					.member(baseMember)
+					.matchMember(targetMember)
+					.score(score)
+					.build();
+
+				scoreRepository.save(matchingScore);
+			}
+		}
+	}
+
+}

--- a/src/main/java/com/palbang/unsemawang/chemistry/testinsert/InsertController.java
+++ b/src/main/java/com/palbang/unsemawang/chemistry/testinsert/InsertController.java
@@ -1,0 +1,23 @@
+package com.palbang.unsemawang.chemistry.testinsert;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/fortune")
+@RequiredArgsConstructor
+public class InsertController {
+	private final InsertDayGanZhi updateService;
+
+	@PutMapping("/update-daygan-zhi")
+	public ResponseEntity<String> batchUpdateDayGanZhi() {
+		int updatedCount = updateService.batchUpdateDayGanZhiForNullValues();
+		return ResponseEntity.ok("총 " + updatedCount + "개의 데이터를 업데이트했습니다.");
+	}
+}

--- a/src/main/java/com/palbang/unsemawang/chemistry/testinsert/InsertDayGanZhi.java
+++ b/src/main/java/com/palbang/unsemawang/chemistry/testinsert/InsertDayGanZhi.java
@@ -1,0 +1,66 @@
+package com.palbang.unsemawang.chemistry.testinsert;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.palbang.unsemawang.fortune.dto.request.FortuneInfoUpdateRequest;
+import com.palbang.unsemawang.fortune.dto.response.FortuneUserInfoUpdateResponse;
+import com.palbang.unsemawang.fortune.entity.FortuneUserInfo;
+import com.palbang.unsemawang.fortune.repository.FortuneUserInfoRepository;
+import com.palbang.unsemawang.fortune.service.FortuneUserInfoUpdateService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class InsertDayGanZhi {
+	private final FortuneUserInfoRepository fortuneUserInfoRepository;
+	private final FortuneUserInfoUpdateService fortuneUserInfoUpdateService;
+
+	public int batchUpdateDayGanZhiForNullValues() {
+		// 1. dayGan 또는 dayZhi가 null인 데이터 조회
+		List<FortuneUserInfo> usersToUpdate = fortuneUserInfoRepository.findByDayGanIsNullOrDayZhiIsNull();
+
+		log.info("총 {}개의 데이터를 업데이트합니다.", usersToUpdate.size());
+
+		int updatedCount = 0;
+
+		for (FortuneUserInfo user : usersToUpdate) {
+			try {
+				updateSingleUser(user); // 개별 업데이트 메서드 호출 (별도 트랜잭션 적용)
+				updatedCount++;
+			} catch (Exception e) {
+				log.error("ID {} 업데이트 실패: {}", user.getId(), e.getMessage());
+			}
+		}
+
+		log.info("업데이트 완료: 총 {}개의 데이터", updatedCount);
+		return updatedCount;
+	}
+
+	// 개별 트랜잭션 적용 (하나만 실패해도 다른 업데이트에 영향 X)
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void updateSingleUser(FortuneUserInfo user) {
+		FortuneInfoUpdateRequest request = FortuneInfoUpdateRequest.builder()
+			.memberId(user.getMember().getId())
+			.relationId(user.getId())
+			.relationName(user.getRelation().getRelationName())
+			.nickname(user.getNickname())
+			.year(user.getYear())
+			.month(user.getMonth())
+			.day(user.getDay())
+			.hour(user.getHour())
+			.sex(user.getSex())
+			.youn(user.getYoun())
+			.solunar(user.getSolunar())
+			.build();
+
+		FortuneUserInfoUpdateResponse response = fortuneUserInfoUpdateService.updateFortuneUserInfo(request);
+		log.info("ID {}: dayGanZhi 업데이트 완료 -> {}", user.getId(), response);
+	}
+}

--- a/src/main/java/com/palbang/unsemawang/fortune/repository/FortuneUserInfoRepository.java
+++ b/src/main/java/com/palbang/unsemawang/fortune/repository/FortuneUserInfoRepository.java
@@ -15,12 +15,17 @@ public interface FortuneUserInfoRepository extends JpaRepository<FortuneUserInfo
 	@Query("SELECT f FROM FortuneUserInfo f WHERE f.member.id = :id AND f.isDeleted = false")
 	List<FortuneUserInfo> findByMemberId(String id);
 
-	@Query("SELECT f FROM FortuneUserInfo f " +
-		"JOIN f.relation r " +
-		"WHERE f.member.id = :id AND r.relationName = :relationName AND f.isDeleted = false")
+	@Query("""
+		SELECT f FROM FortuneUserInfo f
+		JOIN f.relation r
+		WHERE f.member.id = :id AND r.relationName = :relationName AND f.isDeleted = false
+		""")
 	List<FortuneUserInfo> findByMemberIdAndRelation(@Param("id") String id, @Param("relationName") String relationName);
 
 	// FortuneUserInfo에서 dayGan 조회
-	@Query("SELECT f.dayGan FROM FortuneUserInfo f WHERE f.member.id = :memberId AND f.relation.id = 1")
-	Optional<String> findDayGanByMemberId(String memberId);
+	@Query("SELECT f FROM FortuneUserInfo f WHERE f.member.id = :memberId AND f.relation.id = 1")
+	Optional<FortuneUserInfo> findByMemberIdRelationIdIsOne(String memberId);
+
+	// 테스트용: dayGan 또는 dayZhi가 null인 데이터 조회
+	List<FortuneUserInfo> findByDayGanIsNullOrDayZhiIsNull();
 }

--- a/src/main/java/com/palbang/unsemawang/fortune/repository/FortuneUserInfoRepository.java
+++ b/src/main/java/com/palbang/unsemawang/fortune/repository/FortuneUserInfoRepository.java
@@ -1,6 +1,7 @@
 package com.palbang.unsemawang.fortune.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -19,4 +20,7 @@ public interface FortuneUserInfoRepository extends JpaRepository<FortuneUserInfo
 		"WHERE f.member.id = :id AND r.relationName = :relationName AND f.isDeleted = false")
 	List<FortuneUserInfo> findByMemberIdAndRelation(@Param("id") String id, @Param("relationName") String relationName);
 
+	// FortuneUserInfo에서 dayGan 조회
+	@Query("SELECT f.dayGan FROM FortuneUserInfo f WHERE f.member.id = :memberId AND f.relation.id = 1")
+	Optional<String> findDayGanByMemberId(String memberId);
 }

--- a/src/main/java/com/palbang/unsemawang/member/repository/MemberRepository.java
+++ b/src/main/java/com/palbang/unsemawang/member/repository/MemberRepository.java
@@ -1,5 +1,6 @@
 package com.palbang.unsemawang.member.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -8,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import com.palbang.unsemawang.chemistry.dto.MemberWithDayGanDto;
 import com.palbang.unsemawang.member.entity.Member;
 
 @Repository
@@ -23,4 +25,12 @@ public interface MemberRepository extends JpaRepository<Member, String> {
 	Optional<Member> findByNickname(@Param("nickname") String nickname);
 
 	Optional<Member> findById(String id);
+
+	@Query("""
+		    SELECT new com.palbang.unsemawang.chemistry.dto.MemberWithDayGanDto(m.id, f.dayGan)
+		    FROM Member m
+		    JOIN FortuneUserInfo f ON m.id = f.member.id
+		    WHERE f.relation.id = 1
+		""")
+	List<MemberWithDayGanDto> findAllMembersWithDayGan();
 }

--- a/src/test/java/com/palbang/unsemawang/chemistry/constant/ChemistryCalculatorTest.java
+++ b/src/test/java/com/palbang/unsemawang/chemistry/constant/ChemistryCalculatorTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 
+import com.palbang.unsemawang.chemistry.service.ChemistryCalculator;
+
 class ChemistryCalculatorTest {
 
 	@Test


### PR DESCRIPTION
# 🚀 Pull Request
- 채팅 추천 5명 조회 

## #️⃣ 연관된 이슈
- #233 

## 📋 작업 내용
- 이중 for문을 돌려서 baseMember를 기준으로 다른 회원과의 점수 계산하는 로직 구현

## 🔧 변경된 코드 설명
- `FiveElements` 파일
	- "갑" -> "木" 으로 바꾸는 메서드 추가

- `RecommendControllerImpl` 파일
	- 사용자 추천 서비스 요청

- `MemberWithDayGanDto`
	- 점수 계산 시 필요한 정보는 `Member`의 memberId와 `FortuneUserInfo` 의 dayGan
	- `Member`와 `FortuneUserInfo`를 조인하고 `MemberWithDayGanDto`에 담아서 사용

- `ChemistryRecommendResponse`
	- score를 10점 만점으로 전환해서 저장
	- lastActiveDate는 아직 구현 안함(현재는 GPT가 짜준 코드인데 무시 바람)

-`MemberMatchingScore `
	- 더 명확하게 필드명 변경 
	- 점수 업데이트하는 메서드 추가

- `MemberMatchingScoreRepository`
	- `List<MemberMatchingScore> findTop5ByMemberIdOrderByScoreDesc(String memberId);`는 상위 5명 가져오는 메서드
	- `MemberMatchingScore findByMemberAndMatchMember(Member member, Member matchMember);`는 이미 매칭된 row가 있는지 조회

## ✅ 테스트 여부
- [ ] 테스트 코드 실행 여부
- [ ] 서버 실행 여부
- [ ] 스웨거 테스트 여부

## 👽 비고
- 이중 for문 돌리고 조회하니까 응답시간 30초 이상 걸려요 이거 무조건 배치랑 레디스 써야해요
