### PR TITLE
[Feature] 채팅방 목록 조회, 채팅 내역 조회 API 명세 작업 #236

### DIFF
--- a/src/main/java/com/palbang/unsemawang/chat/constant/SendType.java
+++ b/src/main/java/com/palbang/unsemawang/chat/constant/SendType.java
@@ -1,0 +1,12 @@
+package com.palbang.unsemawang.chat.constant;
+
+public enum SendType {
+	SELF("본인"),
+	OTHER("상대방");
+
+	private String desc;
+
+	SendType(String desc) {
+		this.desc = desc;
+	}
+}

--- a/src/main/java/com/palbang/unsemawang/chat/constant/SenderType.java
+++ b/src/main/java/com/palbang/unsemawang/chat/constant/SenderType.java
@@ -1,12 +1,19 @@
 package com.palbang.unsemawang.chat.constant;
 
 public enum SenderType {
-	SELF("본인"),
-	OTHER("상대방");
+	SELF("self", "본인"),
+	OTHER("other", "상대방");
 
+	private String type;
 	private String desc;
 
-	SenderType(String desc) {
+	SenderType(String type, String desc) {
 		this.desc = desc;
+		this.type = type;
+	}
+
+	@Override
+	public String toString() {
+		return this.type;
 	}
 }

--- a/src/main/java/com/palbang/unsemawang/chat/constant/SenderType.java
+++ b/src/main/java/com/palbang/unsemawang/chat/constant/SenderType.java
@@ -1,12 +1,12 @@
 package com.palbang.unsemawang.chat.constant;
 
-public enum SendType {
+public enum SenderType {
 	SELF("본인"),
 	OTHER("상대방");
 
 	private String desc;
 
-	SendType(String desc) {
+	SenderType(String desc) {
 		this.desc = desc;
 	}
 }

--- a/src/main/java/com/palbang/unsemawang/chat/controller/ChatHistoryReadController.java
+++ b/src/main/java/com/palbang/unsemawang/chat/controller/ChatHistoryReadController.java
@@ -1,0 +1,35 @@
+package com.palbang.unsemawang.chat.controller;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.palbang.unsemawang.chat.dto.response.ChatHistoryReadResponse;
+import com.palbang.unsemawang.common.constants.ResponseCode;
+import com.palbang.unsemawang.common.exception.GeneralException;
+import com.palbang.unsemawang.oauth2.dto.CustomOAuth2User;
+
+@RestController
+@RequestMapping("/chemistry/chat-room")
+public class ChatHistoryReadController {
+
+	@GetMapping("/{chatRoomId}/history")
+	public ResponseEntity<List<ChatHistoryReadResponse>> readChatHistory(
+		@AuthenticationPrincipal CustomOAuth2User user,
+		@PathVariable("chatRoomId") Long chatRoomId
+	) {
+		if (user == null || user.getId() == null) {
+			throw new GeneralException(ResponseCode.EMPTY_TOKEN);
+		}
+
+		List<ChatHistoryReadResponse> chatHistory = new LinkedList<>();
+
+		return ResponseEntity.ok().body(chatHistory);
+	}
+}

--- a/src/main/java/com/palbang/unsemawang/chat/controller/ChatHistoryReadController.java
+++ b/src/main/java/com/palbang/unsemawang/chat/controller/ChatHistoryReadController.java
@@ -15,10 +15,18 @@ import com.palbang.unsemawang.common.constants.ResponseCode;
 import com.palbang.unsemawang.common.exception.GeneralException;
 import com.palbang.unsemawang.oauth2.dto.CustomOAuth2User;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "궁합 채팅")
 @RestController
 @RequestMapping("/chemistry/chat-room")
 public class ChatHistoryReadController {
 
+	@Operation(
+		description = "특정 채팅방의 지난 채팅 내역을 조회합니다",
+		summary = "지난 채팅 내역 조회"
+	)
 	@GetMapping("/{chatRoomId}/history")
 	public ResponseEntity<List<ChatHistoryReadResponse>> readChatHistory(
 		@AuthenticationPrincipal CustomOAuth2User user,

--- a/src/main/java/com/palbang/unsemawang/chat/controller/ChatRoomReadController.java
+++ b/src/main/java/com/palbang/unsemawang/chat/controller/ChatRoomReadController.java
@@ -1,0 +1,33 @@
+package com.palbang.unsemawang.chat.controller;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.palbang.unsemawang.chat.dto.response.ChatRoomReadResponse;
+import com.palbang.unsemawang.common.constants.ResponseCode;
+import com.palbang.unsemawang.common.exception.GeneralException;
+import com.palbang.unsemawang.oauth2.dto.CustomOAuth2User;
+
+@RestController
+@RequestMapping("/chemistry/chat-room")
+public class ChatRoomReadController {
+
+	@GetMapping
+	public ResponseEntity<List<ChatRoomReadResponse>> readMyChatRoomList(
+		@AuthenticationPrincipal CustomOAuth2User user
+	) {
+		if (user == null || user.getId() == null) {
+			throw new GeneralException(ResponseCode.EMPTY_TOKEN);
+		}
+
+		List<ChatRoomReadResponse> myChatRoomList = new LinkedList<>();
+
+		return ResponseEntity.ok().body(myChatRoomList);
+	}
+}

--- a/src/main/java/com/palbang/unsemawang/chat/controller/ChatRoomReadController.java
+++ b/src/main/java/com/palbang/unsemawang/chat/controller/ChatRoomReadController.java
@@ -14,10 +14,18 @@ import com.palbang.unsemawang.common.constants.ResponseCode;
 import com.palbang.unsemawang.common.exception.GeneralException;
 import com.palbang.unsemawang.oauth2.dto.CustomOAuth2User;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "궁합 채팅")
 @RestController
 @RequestMapping("/chemistry/chat-room")
 public class ChatRoomReadController {
 
+	@Operation(
+		description = "나의 채팅방 목록을 조회합니다",
+		summary = "나의 채팅방 목록 조회"
+	)
 	@GetMapping
 	public ResponseEntity<List<ChatRoomReadResponse>> readMyChatRoomList(
 		@AuthenticationPrincipal CustomOAuth2User user

--- a/src/main/java/com/palbang/unsemawang/chat/dto/response/ChatHistoryReadResponse.java
+++ b/src/main/java/com/palbang/unsemawang/chat/dto/response/ChatHistoryReadResponse.java
@@ -2,8 +2,9 @@ package com.palbang.unsemawang.chat.dto.response;
 
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,8 +16,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 public class ChatHistoryReadResponse {
-	@JsonAlias("partner")
+
+	@Schema(required = true, description = "채팅 상대 닉네임")
+	@JsonProperty("partner")
 	String partnerNickname;
 
+	@Schema(required = false, description = "채팅 메세지 목록")
 	List<ChatMessageResponse> messages;
 }

--- a/src/main/java/com/palbang/unsemawang/chat/dto/response/ChatHistoryReadResponse.java
+++ b/src/main/java/com/palbang/unsemawang/chat/dto/response/ChatHistoryReadResponse.java
@@ -1,0 +1,22 @@
+package com.palbang.unsemawang.chat.dto.response;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class ChatHistoryReadResponse {
+	@JsonAlias("partner")
+	String partnerNickname;
+
+	List<ChatMessageResponse> messages;
+}

--- a/src/main/java/com/palbang/unsemawang/chat/dto/response/ChatMessageResponse.java
+++ b/src/main/java/com/palbang/unsemawang/chat/dto/response/ChatMessageResponse.java
@@ -3,8 +3,10 @@ package com.palbang.unsemawang.chat.dto.response;
 import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.palbang.unsemawang.chat.constant.SenderType;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,18 +18,24 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 public class ChatMessageResponse {
+	@Schema(required = true, description = "채팅 메세지 내용")
 	private String content;
 
+	@Schema(required = true, description = "보낸 사람 타입")
 	private SenderType senderType;
 
+	@Schema(required = false, description = "보낸 사람 ID")
 	@JsonAlias("userId")
-	private String partnerId;
+	private String senderId;
 
-	@JsonAlias("nickname")
-	private String partnerNickname;
+	@Schema(required = false, description = "보낸 사람 닉네임")
+	@JsonProperty("nickname")
+	private String senderNickname;
 
-	@JsonAlias("profileImageUrl")
-	private String partnerProfileImageUrl;
+	@Schema(required = false, description = "보낸 사람 프로필 사진")
+	@JsonProperty("profileImageUrl")
+	private String senderProfileImageUrl;
 
+	@Schema(required = true, description = "보낸 일시")
 	private LocalDateTime timestamp;
 }

--- a/src/main/java/com/palbang/unsemawang/chat/dto/response/ChatMessageResponse.java
+++ b/src/main/java/com/palbang/unsemawang/chat/dto/response/ChatMessageResponse.java
@@ -3,7 +3,7 @@ package com.palbang.unsemawang.chat.dto.response;
 import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
-import com.palbang.unsemawang.chat.constant.SendType;
+import com.palbang.unsemawang.chat.constant.SenderType;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 public class ChatMessageResponse {
 	private String content;
 
-	private SendType sendType;
+	private SenderType senderType;
 
 	@JsonAlias("userId")
 	private String partnerId;

--- a/src/main/java/com/palbang/unsemawang/chat/dto/response/ChatMessageResponse.java
+++ b/src/main/java/com/palbang/unsemawang/chat/dto/response/ChatMessageResponse.java
@@ -1,0 +1,33 @@
+package com.palbang.unsemawang.chat.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.palbang.unsemawang.chat.constant.SendType;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class ChatMessageResponse {
+	private String content;
+
+	private SendType sendType;
+
+	@JsonAlias("userId")
+	private String partnerId;
+
+	@JsonAlias("nickname")
+	private String partnerNickname;
+
+	@JsonAlias("profileImageUrl")
+	private String partnerProfileImageUrl;
+
+	private LocalDateTime timestamp;
+}

--- a/src/main/java/com/palbang/unsemawang/chat/dto/response/ChatRoomReadResponse.java
+++ b/src/main/java/com/palbang/unsemawang/chat/dto/response/ChatRoomReadResponse.java
@@ -1,0 +1,39 @@
+package com.palbang.unsemawang.chat.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class ChatRoomReadResponse {
+
+	private Long chatRoomId;
+
+	@JsonAlias("userId")
+	private String partnerId;
+
+	@JsonAlias("nickname")
+	private String partnerNickname;
+
+	@JsonAlias("profileImageUrl")
+	private String partnerProfileImageUrl;
+
+	@JsonAlias("sex")
+	private String partnerSex;
+
+	@JsonAlias("five")
+	private String partnerFiveElementCn;
+
+	@JsonAlias("lastChat")
+	private String lastChatMessage;
+	private LocalDateTime lastChatTime;
+}

--- a/src/main/java/com/palbang/unsemawang/chat/dto/response/ChatRoomReadResponse.java
+++ b/src/main/java/com/palbang/unsemawang/chat/dto/response/ChatRoomReadResponse.java
@@ -2,8 +2,9 @@ package com.palbang.unsemawang.chat.dto.response;
 
 import java.time.LocalDateTime;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,24 +17,33 @@ import lombok.NoArgsConstructor;
 @Builder
 public class ChatRoomReadResponse {
 
+	@Schema(required = true, description = "채팅방 고유번호")
 	private Long chatRoomId;
 
-	@JsonAlias("userId")
+	@Schema(required = true, description = "상대방 ID")
+	@JsonProperty("userId")
 	private String partnerId;
 
-	@JsonAlias("nickname")
+	@Schema(required = true, description = "상대방 닉네임")
+	@JsonProperty("nickname")
 	private String partnerNickname;
 
-	@JsonAlias("profileImageUrl")
+	@Schema(required = true, description = "상대방 프로필 이미지 url")
+	@JsonProperty("profileImageUrl")
 	private String partnerProfileImageUrl;
 
-	@JsonAlias("sex")
+	@Schema(required = true, description = "상대방 성별")
+	@JsonProperty("sex")
 	private String partnerSex;
 
-	@JsonAlias("five")
+	@Schema(required = true, description = "상대방 오행(일주) 정보")
+	@JsonProperty("five")
 	private String partnerFiveElementCn;
 
-	@JsonAlias("lastChat")
+	@Schema(required = false, description = "마지막으로 보낸 채팅 메세지")
+	@JsonProperty("lastChat")
 	private String lastChatMessage;
+
+	@Schema(required = false, description = "마지막으로 보낸 채팅 일시")
 	private LocalDateTime lastChatTime;
 }


### PR DESCRIPTION
# 🚀 Pull Request

**채팅방 목록 조회, 채팅 내역 조회 API 명세 작업**

## #️⃣ 연관된 이슈

- Closed #236 

## 📋 작업 내용

- 채팅방 목록 조회, 채팅 내역 조회를 위한 DTO 추가
- 채팅방 목록 조회, 채팅 내역 조회 API 컨트롤러단 추가 및 명세 작업

## 🔧 변경된 코드 설명

.

## ✅ 테스트 여부

- [x] 테스트 코드 실행 여부
- [x] 서버 실행 여부
- [x] 스웨거 테스트 여부

## 👽 비고

- 현재는 프론트와의 병렬작업을 위한 껍데기 API로 빈 리스트를 반환하도록 했습니다
