### PR TITLE
[Feature] 활동중인 회원 저장 및 조회 서비스 구현 #235

### DIFF
--- a/src/main/java/com/palbang/unsemawang/activity/aop/ActivityTraceAspect.java
+++ b/src/main/java/com/palbang/unsemawang/activity/aop/ActivityTraceAspect.java
@@ -1,0 +1,42 @@
+package com.palbang.unsemawang.activity.aop;
+
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import com.palbang.unsemawang.activity.entity.ActiveMember;
+import com.palbang.unsemawang.activity.service.ActiveMemberService;
+import com.palbang.unsemawang.oauth2.dto.CustomOAuth2User;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class ActivityTraceAspect {
+
+	private final ActiveMemberService activeMemberService;
+
+	/**
+	 * 회원이 API 요청을 수행한 후 활동 내역을 Redis에 저장
+	 */
+	@AfterReturning("execution(* com.palbang.unsemawang..controller..*(..)) && !@annotation(com.palbang.unsemawang.activity.aop.NoTracking)")
+	public void trackUserActivity() {
+		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+		if (auth == null || !auth.isAuthenticated()) {
+			log.warn("인증 정보가 없습니다");
+			return;
+		}
+
+		String memberId = ((CustomOAuth2User)auth.getPrincipal()).getId();
+
+		// 레디스 활동 리스트 갱신
+		ActiveMember savedActiveMember = activeMemberService.saveAndUpdateActiveMember(memberId);
+		log.info("저장된 회원 활동 정보: {}", savedActiveMember);
+	}
+}

--- a/src/main/java/com/palbang/unsemawang/activity/aop/NoTracking.java
+++ b/src/main/java/com/palbang/unsemawang/activity/aop/NoTracking.java
@@ -1,0 +1,11 @@
+package com.palbang.unsemawang.activity.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NoTracking {
+}

--- a/src/main/java/com/palbang/unsemawang/activity/controller/ActiveMemberController.java
+++ b/src/main/java/com/palbang/unsemawang/activity/controller/ActiveMemberController.java
@@ -1,0 +1,28 @@
+package com.palbang.unsemawang.activity.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.palbang.unsemawang.activity.aop.NoTracking;
+import com.palbang.unsemawang.activity.entity.ActiveMember;
+import com.palbang.unsemawang.activity.service.ActiveMemberService;
+
+import lombok.RequiredArgsConstructor;
+
+// 최근 10분 내 접속중인 회원 확인용 api
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/active-member")
+public class ActiveMemberController {
+	private final ActiveMemberService activeMemberService;
+
+	@NoTracking
+	@GetMapping
+	public ResponseEntity<List<ActiveMember>> readActiveMemberList() {
+		return ResponseEntity.ok(activeMemberService.findAllActiveMember());
+	}
+}

--- a/src/main/java/com/palbang/unsemawang/activity/entity/ActiveMember.java
+++ b/src/main/java/com/palbang/unsemawang/activity/entity/ActiveMember.java
@@ -1,0 +1,31 @@
+package com.palbang.unsemawang.activity.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Builder
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@RedisHash(value = "activity_member")
+public class ActiveMember {
+	@Id
+	private String memberId;
+
+	@Builder.Default
+	private LocalDateTime lastActiveDateTime = LocalDateTime.now();
+
+	@TimeToLive
+	private Long ttl;
+}

--- a/src/main/java/com/palbang/unsemawang/activity/repository/ActiveMemberRepository.java
+++ b/src/main/java/com/palbang/unsemawang/activity/repository/ActiveMemberRepository.java
@@ -1,0 +1,9 @@
+package com.palbang.unsemawang.activity.repository;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.palbang.unsemawang.activity.entity.ActiveMember;
+
+public interface ActiveMemberRepository extends CrudRepository<ActiveMember, String> {
+
+}

--- a/src/main/java/com/palbang/unsemawang/activity/service/ActiveMemberService.java
+++ b/src/main/java/com/palbang/unsemawang/activity/service/ActiveMemberService.java
@@ -1,0 +1,31 @@
+package com.palbang.unsemawang.activity.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.palbang.unsemawang.activity.entity.ActiveMember;
+import com.palbang.unsemawang.activity.repository.ActiveMemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ActiveMemberService {
+	private final ActiveMemberRepository activeMemberRepository;
+	private static final long ACTIVE_TTL = 900L;
+
+	public ActiveMember saveAndUpdateActiveMember(String memberId) {
+
+		ActiveMember activeMember = ActiveMember.builder()
+			.memberId(memberId)
+			.ttl(ACTIVE_TTL)
+			.build();
+
+		return activeMemberRepository.save(activeMember);
+	}
+
+	public List<ActiveMember> findAllActiveMember() {
+		return (List<ActiveMember>)activeMemberRepository.findAll();
+	}
+}

--- a/src/test/java/com/palbang/unsemawang/activity/repository/ActiveMemberRepositoryTest.java
+++ b/src/test/java/com/palbang/unsemawang/activity/repository/ActiveMemberRepositoryTest.java
@@ -1,0 +1,35 @@
+package com.palbang.unsemawang.activity.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+
+import com.palbang.unsemawang.activity.entity.ActiveMember;
+
+@DataRedisTest
+class ActiveMemberRepositoryTest {
+	@Autowired
+	private ActiveMemberRepository activeMemberRepository;
+
+	@Test
+	@DisplayName("레디스 테스트 - 저장 후 조회")
+	public void saveAndGet() {
+		// given
+		ActiveMember memberActivity = ActiveMember.builder()
+			.memberId("test-user-id")
+			.build();
+
+		activeMemberRepository.save(memberActivity);
+
+		ActiveMember getMemberActivity = activeMemberRepository.findById(memberActivity.getMemberId())
+			.orElse(null);
+
+		assertNotNull(getMemberActivity);
+		assertEquals(memberActivity.getMemberId(), getMemberActivity.getMemberId());
+
+		activeMemberRepository.deleteById(memberActivity.getMemberId());
+	}
+}


### PR DESCRIPTION
# 🚀 Pull Request

**활동중인 회원 저장 및 조회 서비스 구현**

## #️⃣ 연관된 이슈

- Closed #235 

## 📋 작업 내용

- 활동 회원 정보 redis 엔티티 추가
- 레디스에 활동 회원 정보를 갱신 및 조회하는 서비스 로직 구현
- 회원이 api를 호출하면 활동 회원 리스트에 갱신되도록 Aspect 구현
- 위 aop 작업을 막아야하는 경우를 위해 NoTracking 어노테이션 추가
- 테스트용 횔동 회원 리스트 조회 api 구현(별도 명세 작업은 안했습니다)

## 🔧 변경된 코드 설명

.

## ✅ 테스트 여부

- [ ] 테스트 코드 실행 여부
- [ ] 서버 실행 여부
- [ ] 스웨거 테스트 여부

## 👽 비고

- 현재 모든 API 호출 시 회원의 활동 정보를 갱신하도록 설정했습니다
- 이를 원하지 않을 경우 컨트롤러 메서드에 `@NoTracking` 어노테이션을 붙여주세요
