### PR TITLE
[Fix] 채팅내역조회, 궁합추천 API 잘못된 응답 수정 #242

### DIFF
--- a/src/main/java/com/palbang/unsemawang/chat/controller/ChatHistoryReadController.java
+++ b/src/main/java/com/palbang/unsemawang/chat/controller/ChatHistoryReadController.java
@@ -1,8 +1,5 @@
 package com.palbang.unsemawang.chat.controller;
 
-import java.util.LinkedList;
-import java.util.List;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,7 +25,7 @@ public class ChatHistoryReadController {
 		summary = "지난 채팅 내역 조회"
 	)
 	@GetMapping("/{chatRoomId}/history")
-	public ResponseEntity<List<ChatHistoryReadResponse>> readChatHistory(
+	public ResponseEntity<ChatHistoryReadResponse> readChatHistory(
 		@AuthenticationPrincipal CustomOAuth2User user,
 		@PathVariable("chatRoomId") Long chatRoomId
 	) {
@@ -36,7 +33,7 @@ public class ChatHistoryReadController {
 			throw new GeneralException(ResponseCode.EMPTY_TOKEN);
 		}
 
-		List<ChatHistoryReadResponse> chatHistory = new LinkedList<>();
+		ChatHistoryReadResponse chatHistory = ChatHistoryReadResponse.builder().build();
 
 		return ResponseEntity.ok().body(chatHistory);
 	}

--- a/src/main/java/com/palbang/unsemawang/chat/dto/response/ChatMessageResponse.java
+++ b/src/main/java/com/palbang/unsemawang/chat/dto/response/ChatMessageResponse.java
@@ -2,7 +2,6 @@ package com.palbang.unsemawang.chat.dto.response;
 
 import java.time.LocalDateTime;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.palbang.unsemawang.chat.constant.SenderType;
 
@@ -25,7 +24,7 @@ public class ChatMessageResponse {
 	private SenderType senderType;
 
 	@Schema(required = false, description = "보낸 사람 ID")
-	@JsonAlias("userId")
+	@JsonProperty("userId")
 	private String senderId;
 
 	@Schema(required = false, description = "보낸 사람 닉네임")

--- a/src/main/java/com/palbang/unsemawang/chemistry/controller/RecommendController.java
+++ b/src/main/java/com/palbang/unsemawang/chemistry/controller/RecommendController.java
@@ -8,8 +8,6 @@ import com.palbang.unsemawang.chemistry.dto.response.ChemistryRecommendResponse;
 import com.palbang.unsemawang.oauth2.dto.CustomOAuth2User;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
@@ -20,8 +18,7 @@ public interface RecommendController {
 		description = "오행 기반 궁합이 잘맞는 회원 추천 리스트를 조회합니다",
 		summary = "오행 기반 매칭 결과 조회"
 	)
-	@ApiResponse(responseCode = "200", description = "궁합 좋은 회원 추천 리스트 조회 성공",
-		content = @Content(schema = @Schema(implementation = ChemistryRecommendResponse.class)))
+	@ApiResponse(responseCode = "200", description = "궁합 좋은 회원 추천 리스트 조회 성공")
 	ResponseEntity<List<ChemistryRecommendResponse>> recommendChemistryMember(
 		CustomOAuth2User user
 	);


### PR DESCRIPTION
# 🚀 Pull Request

**채팅내역조회, 궁합추천 API 잘못된 응답 수정*

## #️⃣ 연관된 이슈

- Closed #242 

## 📋 작업 내용

- 채팅 내역 조회 API에서 ChatHistortyResponse 객체가 단일 데이터로 응답되어야 하는데 List에 담겨져 응답하고 있어 이를 수정하였습니다
- 궁합 추천 API에서 응답은 제대로 리스트 형태로 가고 있으나, 스웨거 스키마에 단일 데이터로 표시되는 문제가 있어 해당 문제를 일으키는 속성값을 제거하였습니다
- 추가로 ChatMessageResponse에 잘못된 어노테이션을 사용하고 있는 부분을 찾아 해결하였습니다(`JsonAlias` -> `JsonProperty`)

## 🔧 변경된 코드 설명

.

## ✅ 테스트 여부

- [ ] 테스트 코드 실행 여부
- [ ] 서버 실행 여부
- [ ] 스웨거 테스트 여부

## 👽 비고

.