### PR TITLE
[Feat] 채팅관련 jpa 엔티티 생성 #245

### DIFF
--- a/src/main/java/com/palbang/unsemawang/chat/entity/ChatMessage.java
+++ b/src/main/java/com/palbang/unsemawang/chat/entity/ChatMessage.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinColumns;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -31,12 +32,11 @@ public class ChatMessage extends BaseEntity {
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "chat_room_id", nullable = false)
-	private ChatRoom chatRoom;
-
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "sender_id", nullable = false)
-	private ChatParticipant senderId;
+	@JoinColumns({
+		@JoinColumn(name = "chat_room_id", referencedColumnName = "chat_room_id"),
+		@JoinColumn(name = "participant_id", referencedColumnName = "participant_id")
+	})
+	private ChatParticipant sender;
 
 	@Column(name = "message")
 	private String message;

--- a/src/main/java/com/palbang/unsemawang/chat/entity/ChatMessage.java
+++ b/src/main/java/com/palbang/unsemawang/chat/entity/ChatMessage.java
@@ -1,0 +1,47 @@
+package com.palbang.unsemawang.chat.entity;
+
+import java.time.LocalDateTime;
+
+import com.palbang.unsemawang.common.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Builder(toBuilder = true)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "chat_message")
+public class ChatMessage extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "chat_room_id", nullable = false)
+	private ChatRoom chatRoom;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "sender_id", nullable = false)
+	private ChatParticipant senderId;
+
+	@Column(name = "message")
+	private String message;
+
+	@Column(name = "registered_at", updatable = false)
+	@Builder.Default
+	private LocalDateTime registeredAt = LocalDateTime.now();
+}

--- a/src/main/java/com/palbang/unsemawang/chat/entity/ChatParticipant.java
+++ b/src/main/java/com/palbang/unsemawang/chat/entity/ChatParticipant.java
@@ -25,7 +25,7 @@ import lombok.NoArgsConstructor;
 public class ChatParticipant extends BaseEntity {
 	@Id
 	@Column(name = "chat_room_id")
-	private Long id;
+	private Long chatRoomId;
 
 	@Id
 	@Column(name = "participant_id")

--- a/src/main/java/com/palbang/unsemawang/chat/entity/ChatParticipant.java
+++ b/src/main/java/com/palbang/unsemawang/chat/entity/ChatParticipant.java
@@ -1,0 +1,40 @@
+package com.palbang.unsemawang.chat.entity;
+
+import java.time.LocalDateTime;
+
+import com.palbang.unsemawang.common.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@IdClass(ChatParticipantId.class)
+@Builder(toBuilder = true)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "chat_participant")
+public class ChatParticipant extends BaseEntity {
+	@Id
+	@Column(name = "chat_room_id")
+	private Long id;
+
+	@Id
+	@Column(name = "participant_id")
+	private Long participantId;
+
+	@Column(name = "is_exit", nullable = false)
+	@Builder.Default
+	private boolean isExit = false;
+
+	@Column(name = "last_read_at")
+	private LocalDateTime lastReadAt;
+}

--- a/src/main/java/com/palbang/unsemawang/chat/entity/ChatParticipant.java
+++ b/src/main/java/com/palbang/unsemawang/chat/entity/ChatParticipant.java
@@ -28,13 +28,14 @@ import lombok.NoArgsConstructor;
 @Table(name = "chat_participant")
 public class ChatParticipant extends BaseEntity {
 	@Id
-	@Column(name = "chat_room_id")
-	private Long chatRoomId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "chat_room_id")
+	private ChatRoom chatRoom;
 
 	@Id
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "participant_id")
-	private Member participantId;
+	private Member participant;
 
 	@Column(name = "is_exit", nullable = false)
 	@Builder.Default

--- a/src/main/java/com/palbang/unsemawang/chat/entity/ChatParticipant.java
+++ b/src/main/java/com/palbang/unsemawang/chat/entity/ChatParticipant.java
@@ -3,11 +3,15 @@ package com.palbang.unsemawang.chat.entity;
 import java.time.LocalDateTime;
 
 import com.palbang.unsemawang.common.entity.BaseEntity;
+import com.palbang.unsemawang.member.entity.Member;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -28,8 +32,9 @@ public class ChatParticipant extends BaseEntity {
 	private Long chatRoomId;
 
 	@Id
-	@Column(name = "participant_id")
-	private Long participantId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "participant_id")
+	private Member participantId;
 
 	@Column(name = "is_exit", nullable = false)
 	@Builder.Default

--- a/src/main/java/com/palbang/unsemawang/chat/entity/ChatParticipantId.java
+++ b/src/main/java/com/palbang/unsemawang/chat/entity/ChatParticipantId.java
@@ -1,0 +1,18 @@
+package com.palbang.unsemawang.chat.entity;
+
+import java.io.Serializable;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Builder(toBuilder = true)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode
+public class ChatParticipantId implements Serializable {
+	private Long chatId;
+	private Long participantId;
+}

--- a/src/main/java/com/palbang/unsemawang/chat/entity/ChatParticipantId.java
+++ b/src/main/java/com/palbang/unsemawang/chat/entity/ChatParticipantId.java
@@ -10,6 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ChatParticipantId implements Serializable {
-	private Long chatRoomId;
-	private String participantId;
+	private Long chatRoom;
+	private String participant;
 }

--- a/src/main/java/com/palbang/unsemawang/chat/entity/ChatParticipantId.java
+++ b/src/main/java/com/palbang/unsemawang/chat/entity/ChatParticipantId.java
@@ -2,17 +2,14 @@ package com.palbang.unsemawang.chat.entity;
 
 import java.io.Serializable;
 
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
-@Builder(toBuilder = true)
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
 public class ChatParticipantId implements Serializable {
-	private Long chatId;
+	private Long chatRoomId;
 	private Long participantId;
 }

--- a/src/main/java/com/palbang/unsemawang/chat/entity/ChatParticipantId.java
+++ b/src/main/java/com/palbang/unsemawang/chat/entity/ChatParticipantId.java
@@ -11,5 +11,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ChatParticipantId implements Serializable {
 	private Long chatRoomId;
-	private Long participantId;
+	private String participantId;
 }

--- a/src/main/java/com/palbang/unsemawang/chat/entity/ChatRoom.java
+++ b/src/main/java/com/palbang/unsemawang/chat/entity/ChatRoom.java
@@ -1,0 +1,43 @@
+package com.palbang.unsemawang.chat.entity;
+
+import java.time.LocalDateTime;
+
+import com.palbang.unsemawang.common.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Builder(toBuilder = true)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "chat_room")
+public class ChatRoom extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "title")
+	private String title;
+
+	@Column(name = "registered_at", updatable = false)
+	@Builder.Default
+	private LocalDateTime registeredAt = LocalDateTime.now();
+
+	@Column(name = "is_deleted")
+	@Builder.Default
+	private Boolean isDeleted = false;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+}


### PR DESCRIPTION
# 🚀 Pull Request
- 채팅관련 jpa 엔티티 생성

## #️⃣ 연관된 이슈
- #245 

## 📋 작업 내용
- 채팅 엔티티 생성 
- `ChatParicipant`엔티티에서 복합키를 설정
    - 복합키 설정 방법엔 2가지 존재
    1. `@EmbeddedId` 사용 : 가독성, 유지보수성 좋음
    2. `@IdClass` 사용 : `@Id`사용으로 직관적
    - 직관적으로 복합키임을 보이려고 2번 방법 채택

## 🔧 변경된 코드 설명
- X

## ✅ 테스트 여부
- [x] 테스트 코드 실행 여부
- [ ] 서버 실행 여부
- [ ] 스웨거 테스트 여부

## 👽 비고

기타 알림 사항이 있으면 적어주세요.
