### PR TITLE
[Feat] 커뮤니티: "운세공유게시판" 카테고리 추가 #246

### DIFF
--- a/src/main/java/com/palbang/unsemawang/common/constants/ResponseCode.java
+++ b/src/main/java/com/palbang/unsemawang/common/constants/ResponseCode.java
@@ -63,6 +63,7 @@ public enum ResponseCode implements Codable {
 	NOT_EXIST_FORTUNE_USER_INFO("6133", HttpStatus.BAD_REQUEST, "해당 사주 정보를 찾을 수 없습니다."),
 	NOT_EXIST_USER_RELATION("6134", HttpStatus.BAD_REQUEST, "해당 사주 관계를 찾을 수 없습니다."),
 	NOT_CHANGED_RELATION("6135", HttpStatus.BAD_REQUEST, "본인 관계는 수정할 수 없습니다."),
+	NOT_UPDATED_SHARE_FORTUNE_CATEGORY("6136", HttpStatus.BAD_REQUEST, "운세공유 게시판은 수정이 불가합니다."),
 
 	//  유효성 검사 오류 (형식: 62xx)
 	NOT_LITERAL("6211", HttpStatus.BAD_REQUEST, "문자열 형식이 아님"),

--- a/src/main/java/com/palbang/unsemawang/community/constant/CommunityCategory.java
+++ b/src/main/java/com/palbang/unsemawang/community/constant/CommunityCategory.java
@@ -2,5 +2,6 @@ package com.palbang.unsemawang.community.constant;
 
 public enum CommunityCategory {
 	FREE_BOARD,             // 자유 게시판
-	ANONYMOUS_BOARD;        // 익명 게시판
+	ANONYMOUS_BOARD,        // 익명 게시판
+	SHARE_FORTUNE_BOARD;            // 운세 공유 게시판
 }

--- a/src/main/java/com/palbang/unsemawang/community/constant/CommunityListCategory.java
+++ b/src/main/java/com/palbang/unsemawang/community/constant/CommunityListCategory.java
@@ -1,7 +1,8 @@
 package com.palbang.unsemawang.community.constant;
 
 public enum CommunityListCategory {
-    FREE_BOARD,             // 자유 게시판
-    ANONYMOUS_BOARD,        // 익명 게시판
-    POPULAR_BOARD;
+	FREE_BOARD,             // 자유 게시판
+	ANONYMOUS_BOARD,        // 익명 게시판
+	SHARE_FORTUNE_BOARD,          // 운세 공유 게시판
+	POPULAR_BOARD;
 }

--- a/src/main/java/com/palbang/unsemawang/community/service/PostService.java
+++ b/src/main/java/com/palbang/unsemawang/community/service/PostService.java
@@ -11,6 +11,7 @@ import com.palbang.unsemawang.common.exception.GeneralException;
 import com.palbang.unsemawang.common.util.file.constant.FileReferenceType;
 import com.palbang.unsemawang.common.util.file.dto.FileRequest;
 import com.palbang.unsemawang.common.util.file.service.FileService;
+import com.palbang.unsemawang.community.constant.CommunityCategory;
 import com.palbang.unsemawang.community.dto.request.PostDeleteRequest;
 import com.palbang.unsemawang.community.dto.request.PostRegisterRequest;
 import com.palbang.unsemawang.community.dto.request.PostUpdateRequest;
@@ -80,6 +81,10 @@ public class PostService {
 	@Transactional(rollbackFor = Exception.class)
 	public Post updatePostAndImgFiles(String memberId, Long postId, PostUpdateRequest postUpdateRequest,
 		List<MultipartFile> fileList) {
+
+		if (postUpdateRequest.getCategory() == CommunityCategory.SHARE_FORTUNE_BOARD) {
+			throw new GeneralException(ResponseCode.NOT_UPDATED_SHARE_FORTUNE_CATEGORY);
+		}
 
 		Post updatedPost = update(memberId, postId, postUpdateRequest);
 


### PR DESCRIPTION
# 🚀 Pull Request
- "운세공유게시판" 카테고리 추가

## #️⃣ 연관된 이슈
- #246 

## 📋 작업 내용
- 운세 공유 게시판 카테고리를 추가
- 운세 공유 게시판은 조회, 삭제, 댓글CRUD만 가능
- 수정은 불가능

## 🔧 변경된 코드 설명
- 게시글 수정 서비스에서 커뮤니티 카테고리가 "SHARE_FORTUNE_BOARD"이면 수정 불가능하게 검증 추가

## ✅ 테스트 여부
- [x] 테스트 코드 실행 여부
- [x] 서버 실행 여부
- [x] 스웨거 테스트 여부

## 👽 비고
- FE분과 상의 후 운세 공유 게시판은 수정하지 못하게 했습니다.
