### PR TITLE
[Fix] 추천 사용자4명, 상대방 프로필 이미지 전달 #248

### DIFF
--- a/src/main/java/com/palbang/unsemawang/chemistry/controller/RecommendControllerImpl.java
+++ b/src/main/java/com/palbang/unsemawang/chemistry/controller/RecommendControllerImpl.java
@@ -8,7 +8,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.palbang.unsemawang.chemistry.batch.TotalCalculationService;
 import com.palbang.unsemawang.chemistry.dto.response.ChemistryRecommendResponse;
 import com.palbang.unsemawang.chemistry.service.RecommendService;
 import com.palbang.unsemawang.common.constants.ResponseCode;
@@ -23,7 +22,6 @@ import lombok.RequiredArgsConstructor;
 public class RecommendControllerImpl implements RecommendController {
 
 	private final RecommendService recommendService;
-	private final TotalCalculationService totalCalculationService;
 
 	@GetMapping("/recommendations")
 	@Override
@@ -34,7 +32,7 @@ public class RecommendControllerImpl implements RecommendController {
 			throw new GeneralException(ResponseCode.EMPTY_TOKEN);
 		}
 
-		List<ChemistryRecommendResponse> recommendedMemberList = recommendService.getTop5Matches(auth.getId());
+		List<ChemistryRecommendResponse> recommendedMemberList = recommendService.getTopMatches(auth.getId());
 
 		return ResponseEntity.ok(recommendedMemberList);
 	}

--- a/src/main/java/com/palbang/unsemawang/chemistry/repository/MemberMatchingScoreRepository.java
+++ b/src/main/java/com/palbang/unsemawang/chemistry/repository/MemberMatchingScoreRepository.java
@@ -11,7 +11,7 @@ import com.palbang.unsemawang.member.entity.Member;
 @Repository
 public interface MemberMatchingScoreRepository extends JpaRepository<MemberMatchingScore, Long> {
 
-	List<MemberMatchingScore> findTop5ByMemberIdOrderByScoreDesc(String memberId);
+	List<MemberMatchingScore> findTop4ByMemberIdOrderByScoreDesc(String memberId);
 
 	MemberMatchingScore findByMemberAndMatchMember(Member member, Member matchMember);
 }

--- a/src/main/java/com/palbang/unsemawang/chemistry/service/RecommendService.java
+++ b/src/main/java/com/palbang/unsemawang/chemistry/service/RecommendService.java
@@ -28,24 +28,24 @@ public class RecommendService {
 	private final FileService fileService;
 
 	@Transactional(readOnly = true)
-	public List<ChemistryRecommendResponse> getTop5Matches(String memberId) {
+	public List<ChemistryRecommendResponse> getTopMatches(String memberId) {
 		Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> new GeneralException(ResponseCode.NOT_EXIST_MEMBER_ID));
 
-		List<MemberMatchingScore> matchingScores = memberMatchingScoreRepository.findTop5ByMemberIdOrderByScoreDesc(
+		List<MemberMatchingScore> matchingScores = memberMatchingScoreRepository.findTop4ByMemberIdOrderByScoreDesc(
 			member.getId());
 
 		if (matchingScores.isEmpty()) {
-			throw new GeneralException(ResponseCode.ERROR_SEARCH);
+			throw new GeneralException(ResponseCode.NOT_MATCHING_PEOPLE);
 		}
 
 		// 최대 점수 찾기
 		int maxScore = matchingScores.get(0).getScore(); // 가장 높은 점수 기준으로 스케일링
-		String imgUrl = fileService.getProfileImgUrl(memberId);
-		
+
 		return matchingScores.stream()
 			.map(score -> {
 				String matchMemberId = score.getMatchMember().getId();
+				String imgUrl = fileService.getProfileImgUrl(matchMemberId);
 				FortuneUserInfo fortuneUserInfo = fortuneUserInfoRepository.findByMemberIdRelationIdIsOne(matchMemberId)
 					.orElseThrow(() -> new GeneralException(ResponseCode.ERROR_SEARCH));
 

--- a/src/main/java/com/palbang/unsemawang/common/constants/ResponseCode.java
+++ b/src/main/java/com/palbang/unsemawang/common/constants/ResponseCode.java
@@ -63,6 +63,7 @@ public enum ResponseCode implements Codable {
 	NOT_EXIST_FORTUNE_USER_INFO("6133", HttpStatus.BAD_REQUEST, "해당 사주 정보를 찾을 수 없습니다."),
 	NOT_EXIST_USER_RELATION("6134", HttpStatus.BAD_REQUEST, "해당 사주 관계를 찾을 수 없습니다."),
 	NOT_CHANGED_RELATION("6135", HttpStatus.BAD_REQUEST, "본인 관계는 수정할 수 없습니다."),
+	NOT_MATCHING_PEOPLE("6135", HttpStatus.BAD_REQUEST, "추천된 사용자 리스트가 없습니다."),
 
 	//  유효성 검사 오류 (형식: 62xx)
 	NOT_LITERAL("6211", HttpStatus.BAD_REQUEST, "문자열 형식이 아님"),


### PR DESCRIPTION
# 🚀 Pull Request
- 추천 사용자 5명-> 4명
- 추천 사용자 프로필 이미지 변경

## #️⃣ 연관된 이슈
- #248 

## 📋 작업 내용


## 🔧 변경된 코드 설명
- 추천 사용자 프로필 이미지가 본인 프로필 이미지가 전달되고 있었는데, 상대방 프로필 이미지로 변경
- 추천 사용자 5명에서 4명으로 수정

## ✅ 테스트 여부
- [x] 테스트 코드 실행 여부
- [x] 서버 실행 여부
- [x] 스웨거 테스트 여부

## 👽 비고

기타 알림 사항이 있으면 적어주세요.
