### PR TITLE
[Fix] 활동 정보 저장 aop 주석 처리

### DIFF
--- a/src/main/java/com/palbang/unsemawang/activity/aop/ActivityTraceAspect.java
+++ b/src/main/java/com/palbang/unsemawang/activity/aop/ActivityTraceAspect.java
@@ -1,6 +1,5 @@
 package com.palbang.unsemawang.activity.aop;
 
-import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.Authentication;
@@ -35,7 +34,7 @@ public class ActivityTraceAspect {
 	/**
 	 * 회원이 API 요청을 수행한 후 활동 내역을 Redis에 저장
 	 */
-	@AfterReturning("execution(* com.palbang.unsemawang..controller..*(..)) && !@annotation(com.palbang.unsemawang.activity.aop.NoTracking)")
+	// @AfterReturning("execution(* com.palbang.unsemawang..controller..*(..)) && !@annotation(com.palbang.unsemawang.activity.aop.NoTracking)")
 	public void trackUserActivity() {
 
 		if (!isRedisConnected()) {


### PR DESCRIPTION
# 🚀 Pull Request

**활동 정보 저장 aop 주석 처리**

## #️⃣ 연관된 이슈

- Closed #261 

## 📋 작업 내용

레디스 연결이 될때까지 api 요청마다 활동 정보를 저장하는 aop 기능을 막아두겠습니다

## 🔧 변경된 코드 설명


## ✅ 테스트 여부

- [ ] 테스트 코드 실행 여부
- [ ] 서버 실행 여부
- [ ] 스웨거 테스트 여부

## 👽 비고


