### PR TITLE
Refactor: pr merge 이후에 빌드+배포 되도록 gradle.yml 수정

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -3,8 +3,6 @@ name: CI/CD with Docker
 on:
   push:
     branches: [ "dev" ]
-  pull_request:
-    branches: [ "dev" ]
   workflow_dispatch:
 
 jobs:
@@ -12,7 +10,6 @@ jobs:
 
     runs-on: ubuntu-24.04-arm 
     # runner 찾기 : https://docs.github.com/ko/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
-    if: github.event_name == 'pull_request'
     
     steps:
       - name: Checkout code
@@ -38,7 +35,7 @@ jobs:
   deploy:
     
     runs-on: ubuntu-24.04-arm
-    if: github.event_name == 'push'
+    needs: build
     
     steps:
       - name: Set up SSH


### PR DESCRIPTION

# 🚀 Pull Request

**[pr merge 이후에 빌드+배포 되도록 gradle.yml 수정]**

## #️⃣ 연관된 이슈

#215

## 📋 작업 내용

- pr 단계에서의 빌드를 빼고 push 후 빌드+배포 작업 수행하도록 변경

