### PR TITLE
[Fix] redis 연결 #273

### DIFF
--- a/src/main/java/com/palbang/unsemawang/common/util/redis/RedisHealthCheckController.java
+++ b/src/main/java/com/palbang/unsemawang/common/util/redis/RedisHealthCheckController.java
@@ -1,0 +1,33 @@
+package com.palbang.unsemawang.common.util.redis;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "레디스")
+public class RedisHealthCheckController {
+
+	/**
+	 * Redis Health check를 위한 클래스
+	 * 필요 없어지면 삭제해주셔도 무방합니다
+	 */
+
+	private final RedisHealthCheckService redisService;
+
+	@Operation(
+		summary = "테스트 용도",
+		description = "레디스가 살아 있으면 값을 저장하고 그 값을 가져옵니다"
+	)
+	@GetMapping("/health-check")
+	public String testRedisConnection(@RequestParam String key, @RequestParam String value) {
+		// Redis에 값을 설정하고 그 값을 가져옴
+		return redisService.setAndGetValue(key, value);
+	}
+
+}

--- a/src/main/java/com/palbang/unsemawang/common/util/redis/RedisHealthCheckService.java
+++ b/src/main/java/com/palbang/unsemawang/common/util/redis/RedisHealthCheckService.java
@@ -1,0 +1,27 @@
+package com.palbang.unsemawang.common.util.redis;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RedisHealthCheckService {
+
+	/**
+	 * Redis Health check를 위한 클래스
+	 * 필요 없어지면 삭제해주셔도 무방합니다
+	 */
+
+	private final StringRedisTemplate redisTemplate;
+
+	public String setAndGetValue(String key, String value) {
+		// 값을 Redis에 저장
+		redisTemplate.opsForValue().set(key, value);
+
+		// Redis에서 값을 가져옴
+		return redisTemplate.opsForValue().get(key);
+	}
+
+}

--- a/src/main/java/com/palbang/unsemawang/config/RedisConfig.java
+++ b/src/main/java/com/palbang/unsemawang/config/RedisConfig.java
@@ -1,0 +1,32 @@
+package com.palbang.unsemawang.config;
+
+import java.time.Duration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+public class RedisConfig {
+	@Value("${spring.data.redis.host}")
+	public String host;
+
+	@Value("${spring.data.redis.port}")
+	public int port;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+
+		LettuceClientConfiguration clientConfiguration = LettuceClientConfiguration.builder()
+			.useSsl()    // SSL 사용 설정 : mandatory to use elasti-cache
+			.and()
+			.commandTimeout(Duration.ofSeconds(5))
+			.build();
+
+		return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port), clientConfiguration);
+	}
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -55,7 +55,7 @@ server.tomcat.max-http-form-post-size=15MB
 # Redis
 spring.data.redis.host=${REDIS_HOST}
 spring.data.redis.port=${REDIS_PORT}
-spring.data.redis.connect-timeout=500
+spring.data.redis.connect-timeout=3000
 # HikariCP? ?? ??? ??? MySQL? max_connections ?? ??? ??
 spring.datasource.hikari.maximum-pool-size=20
 # ?? ?? ???? ?? ??? ??


### PR DESCRIPTION
# 🚀 Pull Request

**[Redis 연결 수정]**

## #️⃣ 연관된 이슈

#273

## 📋 작업 내용

SSL 사용 설정을 통해 ElastiCache와 연결 가능하도록 하였습니다

## 🔧 변경된 코드 설명

- RedisConnectionFactory 빈을 추가하여 Lettuce 클라이언트를 통한 Redis 연결을 설정.
- ElastiCache 사용을 위해 SSL 연결을 활성화. (중요)
- Redis 명령어 타임아웃을 5초로 설정하여 응답 지연을 방지.
- RedisStandaloneConfiguration을 사용하여 Redis 서버의 호스트와 포트 설정.
- Redis 서버와의 연결 안정성을 위해 Redis 연결 타임아웃을 3초로 설정하여 네트워크 지연이나 서버 응답 시간에 대한 여유를 추가.
- health-check를 위한 컨트롤러와 서비스 추가

## ✅ 테스트 여부

- [ ] 테스트 코드 실행 여부
- [x] 서버 실행 여부 
- [x] 스웨거 테스트 여부
- [x] 배포 시 동작 여부
