### PR TITLE
feat:fcm 비활성화 기능 추가 및 조회 수정

### DIFF
--- a/src/main/java/com/palbang/unsemawang/common/constants/ResponseCode.java
+++ b/src/main/java/com/palbang/unsemawang/common/constants/ResponseCode.java
@@ -65,6 +65,7 @@ public enum ResponseCode implements Codable {
 	NOT_CHANGED_RELATION("6135", HttpStatus.BAD_REQUEST, "본인 관계는 수정할 수 없습니다."),
 	NOT_MATCHING_PEOPLE("6136", HttpStatus.BAD_REQUEST, "추천된 사용자 리스트가 없습니다."),
 	NOT_UPDATED_SHARE_BOARD_CATEGORY("6137", HttpStatus.BAD_REQUEST, "운세공유 게시판은 수정이 불가합니다."),
+	INVALID_FCM_TOKEN("6138",HttpStatus.BAD_REQUEST, "해당 FCM 토큰은 해당 회원의 것이 아닙니다."),
 
 
 	//  유효성 검사 오류 (형식: 62xx)
@@ -79,6 +80,7 @@ public enum ResponseCode implements Codable {
 	DUPLICATED_VALUE("6223", HttpStatus.CONFLICT, "이미 사용 중인 닉네임 입니다."),
 	NOT_EXIST_TENGAN("6224", HttpStatus.BAD_REQUEST, "십간(十干)이 존재하지 않습니다."),
 	NOT_EXIST_FCM_TOKEN("6225", HttpStatus.BAD_REQUEST, "FCM 토큰이 존재하지 않습니다."),
+	NOT_EXIST_ACTIVE_FCM_TOKEN("6226", HttpStatus.BAD_REQUEST, "활성화된 FCM 토큰이 존재하지 않습니다."),
 
 	// 유효성 검사 오류 (값: 63xx)
 	EMPTY_PARAM_BLANK_OR_NULL("6300", HttpStatus.BAD_REQUEST, "Request Parameter 빈 값, NULL 또는 공백"),

--- a/src/main/java/com/palbang/unsemawang/fcm/controller/FcmController.java
+++ b/src/main/java/com/palbang/unsemawang/fcm/controller/FcmController.java
@@ -1,14 +1,17 @@
 package com.palbang.unsemawang.fcm.controller;
 
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.google.firebase.messaging.FirebaseMessagingException;
@@ -83,12 +86,14 @@ public class FcmController {
 		description = "로그인한 회원의 FCM 토큰을 조회합니다."
 	)
 	@GetMapping("/token")
-	public ResponseEntity<String> getFcmToken(@AuthenticationPrincipal CustomOAuth2User auth) {
+	public ResponseEntity<List<String>> getFcmToken(@AuthenticationPrincipal CustomOAuth2User auth) {
 		if (auth == null || auth.getId() == null) {
 			throw new GeneralException(ResponseCode.EMPTY_TOKEN);
 		}
-		String fcmToken = fcmService.getFcmToken(auth.getId());
-		return ResponseEntity.ok(fcmToken);
+		List<String> fcmTokenList = fcmService.getFcmToken(auth.getId());
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.body(fcmTokenList);
 	}
 
 	@Operation(
@@ -103,6 +108,20 @@ public class FcmController {
 		fcmService.deleteFcmToken(auth.getId());
 		return ResponseEntity.noContent().build();
 	}
+	@Operation(
+		summary = "FCM 토큰 비활성화",
+		description = "회원의 FCM 토큰을 비활성화합니다."
+	)
+	@PatchMapping("/token/deactivate")
+	public ResponseEntity<Void> deactivateFcmToken(@AuthenticationPrincipal CustomOAuth2User auth,String fcmToken) {
+		if (auth == null || auth.getId() == null) {
+			throw new GeneralException(ResponseCode.EMPTY_TOKEN);
+		}
+		fcmService.deactivateFcmToken(auth.getId(),fcmToken);
+		return ResponseEntity.noContent().build();
+	}
+
+
 
 
 }

--- a/src/main/java/com/palbang/unsemawang/fcm/dto/request/FcmTokenRegiRequest.java
+++ b/src/main/java/com/palbang/unsemawang/fcm/dto/request/FcmTokenRegiRequest.java
@@ -18,8 +18,8 @@ import lombok.Setter;
 public class FcmTokenRegiRequest {
 	@Schema(description = "FCM토큰", required = true, example = "ftyp3szqbFgZoWgtJfK-vI:APA91bHaDYCc42JWuwhc-1wSifRQAbOMz_x3ofF5pIhe6eivUNi9-Yop7BD8bePcjevZnx02JwpeOWGO2J-PQjjJjvWtoFLe3My1x5VNDlBKaJIma10Qbww")
 	private String fcmToken;
-	@Schema(description = "기기타입", required = true, example = "WEB")
+	@Schema(description = "기기타입", required = false, example = "WEB")
 	private DeviceType deviceType;
-	@Schema(description = "브라우저종류", required = true, example = "CHROME")
+	@Schema(description = "브라우저종류", required = false, example = "CHROME")
 	private BrowserType browserType;
 }

--- a/src/main/java/com/palbang/unsemawang/fcm/entity/FcmToken.java
+++ b/src/main/java/com/palbang/unsemawang/fcm/entity/FcmToken.java
@@ -39,20 +39,26 @@ public class FcmToken extends BaseEntity {
 	@JoinColumn(name = "member_id", nullable = false)  // 외래 키(FK)
 	private Member member;
 
-	@Column(nullable = false, unique = true)
+	@Column(nullable = false)
 	private String fcmToken;
 
 	@Enumerated(EnumType.STRING)
-	@Column(nullable = false)
+	@Column(nullable = true)
 	private DeviceType deviceType;
 
 	@Enumerated(EnumType.STRING)
-	@Column(nullable = false)
+	@Column(nullable = true)
 	private BrowserType browserType;  // 브라우저 타입
 
 	@Column(name = "updated_at", nullable = true)
 	private LocalDateTime updatedAt;
 
-	@Column(name = "registeredAt", nullable = true)
+	@Column(name = "registered_at", nullable = true)
 	private LocalDateTime registeredAt;
+
+	@Column(name ="is_active" , nullable = false)
+	private Boolean isActive; //활성화 여부
+
+	@Column(name ="expires_at", nullable = true)
+	private LocalDateTime expiresAt;
 }

--- a/src/main/java/com/palbang/unsemawang/fcm/repository/FcmRepository.java
+++ b/src/main/java/com/palbang/unsemawang/fcm/repository/FcmRepository.java
@@ -1,8 +1,11 @@
 package com.palbang.unsemawang.fcm.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.palbang.unsemawang.fcm.constant.BrowserType;
@@ -11,11 +14,12 @@ import com.palbang.unsemawang.fcm.entity.FcmToken;
 
 @Repository
 public interface FcmRepository extends JpaRepository<FcmToken,String> {
-	List<FcmToken> findByFcmToken(String FcmToken);
-	List<FcmToken> findByMemberId(String memberId);
-	List<FcmToken> findByMemberIdAndDeviceType(String memberId, DeviceType deviceType);
-	List<FcmToken> findByMemberIdAndDeviceTypeAndBrowserType(String memberId, DeviceType deviceType, BrowserType browserType);
+	List<FcmToken> findByMemberIdAndFcmToken(String memberId, String fcmToken);
 
+	@Query("SELECT f.fcmToken FROM FcmToken f WHERE f.member.id = :memberId AND f.isActive = true")
+	List<String> findByMemberIdAndIsActive(@Param("memberId") String memberId);
 	boolean existsByMemberId(String memberId);
 	void deleteByMemberId(String memberId);
+
+	Optional<FcmToken> findFirstByFcmTokenAndIsActive(String fcmToken,boolean isActive);
 }

--- a/src/main/java/com/palbang/unsemawang/fcm/service/FcmService.java
+++ b/src/main/java/com/palbang/unsemawang/fcm/service/FcmService.java
@@ -35,7 +35,7 @@ public class FcmService {
 		// 기존 토큰이 있는지 확인 (중복 방지)
 		// 토큰이 존재하는지 체크 이미 존재하면... 이미 등록된 fcm 토큰입니다. 라고 안내..
 
-		List<FcmToken> existingToken = fcmRepository.findByFcmToken(fcmToken);
+		List<FcmToken> existingToken = fcmRepository.findByMemberIdAndFcmToken(memberId,fcmToken);
 		if (existingToken.isEmpty()) {
 			// 새로운 FCM 토큰 저장
 			FcmToken newToken = FcmToken.builder()
@@ -44,6 +44,7 @@ public class FcmService {
 				.deviceType(deviceType)
 				.browserType(browserType)
 				.registeredAt(LocalDateTime.now())
+				.isActive(true)
 				.build();
 
 			fcmRepository.save(newToken);
@@ -51,7 +52,9 @@ public class FcmService {
 		} else {
 			//기존 토큰이 있다면 업데이트
 			FcmToken token = existingToken.get(0);
-			token.setFcmToken(fcmToken);
+			if (!token.getIsActive()) {  // isActive가 false면 true로 변경
+				token.setIsActive(true);
+			}
 			token.setUpdatedAt(LocalDateTime.now());
 			return false;  // 기존 토큰이 업데이트됨
 		}
@@ -63,7 +66,7 @@ public class FcmService {
 		String body = request.getBody();
 		String url = request.getUrl();
 
-		// 푸시 알림 메시지 생성
+		// 푸시 알림 메시지 생성(우선 notification =>data로 변경할 수도 있음)
 		Notification notification = Notification.builder()
 			.setTitle(title)
 			.setBody(body)
@@ -81,14 +84,14 @@ public class FcmService {
 		return FirebaseMessaging.getInstance().send(message);
 	}
 
-	public String getFcmToken(String memberId) {
+	public List<String> getFcmToken(String memberId) {
 		Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> new GeneralException(ResponseCode.NOT_EXIST_MEMBER_ID, "회원을 찾을 수 없습니다"));
-		List<FcmToken> fcmToken = fcmRepository.findByMemberId(memberId);
-		if (fcmToken.isEmpty()) {
+		List<String> fcmTokenList = fcmRepository.findByMemberIdAndIsActive(memberId);
+		if (fcmTokenList.isEmpty()) {
 			return null;
 		}else{
-			return fcmToken.get(0).getFcmToken();
+			return fcmTokenList;
 		}
 	}
 
@@ -102,7 +105,23 @@ public class FcmService {
 			throw new GeneralException(ResponseCode.NOT_EXIST_FCM_TOKEN, "FCM 토큰이 존재하지 않습니다.");
 		}
 		fcmRepository.deleteByMemberId(memberId);
+	}
 
+	@Transactional
+	public void deactivateFcmToken(String memberId,String fcmToken){
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new GeneralException(ResponseCode.NOT_EXIST_MEMBER_ID, "회원을 찾을 수 없습니다"));
 
+		// 활성화된 FCM 토큰 조회 (Optional 사용)
+		FcmToken fcmTokenEntity = fcmRepository.findFirstByFcmTokenAndIsActive(fcmToken, true)
+			.orElseThrow(() -> new GeneralException(ResponseCode.NOT_EXIST_ACTIVE_FCM_TOKEN, "활성화된 FCM 토큰이 존재하지 않습니다."));
+
+		// 해당 FCM 토큰이 해당 회원의 것인지 검증
+		if (!fcmTokenEntity.getMember().getId().equals(memberId)) {
+			throw new GeneralException(ResponseCode.INVALID_FCM_TOKEN, "해당 FCM 토큰은 해당 회원의 것이 아닙니다.");
+		}
+
+		// 토큰 비활성화
+		fcmTokenEntity.setIsActive(false);
 	}
 }


### PR DESCRIPTION
# 🚀 Pull Request

feat:fcm 비활성화 기능 추가 및 조회 수정

## #️⃣ 연관된 이슈

- #272 

## 📋 작업 내용

1.토큰 저장로직 수정
- 새로운 FCM 토큰 저장시 활성화(isActive => false->true)
- 저장시 해당 토큰으로 조회 비활성화된 코드가 존재한다면 활성화(isActive => false->true)

2.토큰 조회 수정 및 비활성화 추가
- 회원 토큰 조회 수정
- 회원 해당 토큰 조회후 비활성화 기능 추가

3.엔티티 수정
- DeviceType, BrowserType 값 필수 => 필수X
- isActive 활성여부 추가
- expiresAt 만료기한 추가

4.ResponseCode 추가
- INVALID_FCM_TOKEN("6138",HttpStatus.BAD_REQUEST, "해당 FCM 토큰은 해당 회원의 것이 아닙니다."),
- NOT_EXIST_ACTIVE_FCM_TOKEN("6226", HttpStatus.BAD_REQUEST, "활성화된 FCM 토큰이 존재하지 않습니다."),

## 🔧 변경된 코드 설명


## ✅ 테스트 여부

이 PR에 포함된 코드에 대해 테스트가 진행되었는지 작성해 주세요.
예시: 단위 테스트 작성 완료, 통합 테스트 완료, UI 테스트 진행 중
- [ ] 테스트 코드 실행 여부
- [x] 서버 실행 여부
- [x] 스웨거 테스트 여부

## 👽 비고

기타 알림 사항이 있으면 적어주세요.
