### PR TITLE
[Feature] 채팅방 리스트를 보고 있을 경우 새로운 메세지 핸들링 #296

### DIFF
--- a/src/main/java/com/palbang/unsemawang/activity/service/ActiveMemberService.java
+++ b/src/main/java/com/palbang/unsemawang/activity/service/ActiveMemberService.java
@@ -4,11 +4,14 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
+import com.palbang.unsemawang.activity.constant.ActiveStatus;
 import com.palbang.unsemawang.activity.dto.ActiveMemberSaveRequest;
 import com.palbang.unsemawang.activity.entity.ActiveMember;
 import com.palbang.unsemawang.activity.repository.ActiveMemberRedisRepository;
 import com.palbang.unsemawang.common.constants.ResponseCode;
 import com.palbang.unsemawang.common.exception.GeneralException;
+import com.palbang.unsemawang.member.entity.Member;
+import com.palbang.unsemawang.member.repository.MemberRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -17,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 public class ActiveMemberService {
 	private final ActiveMemberRedisRepository activeMemberRepository;
 	private static final long ACTIVE_TTL = 900L;
+	private final MemberRepository memberRepository;
 
 	public ActiveMember saveActiveMember(ActiveMemberSaveRequest activeMemberDto) {
 
@@ -30,9 +34,18 @@ public class ActiveMemberService {
 	}
 
 	public ActiveMember findActiveMemberById(String memberId) {
-		ActiveMember activeMemberEntity = activeMemberRepository.findById(memberId).orElseThrow(
+
+		Member member = memberRepository.findById(memberId).orElseThrow(
 			() -> new GeneralException(ResponseCode.NOT_EXIST_UNIQUE_NO)
 		);
+
+		ActiveMember activeMemberEntity = activeMemberRepository.findById(member.getId())
+			.orElse(ActiveMember.builder()
+				.memberId(member.getId())
+				.status(ActiveStatus.INACTIVE)
+				.lastActiveAt(member.getLastActivityAt())
+				.build()
+			);
 		return activeMemberEntity;
 	}
 }

--- a/src/main/java/com/palbang/unsemawang/chat/dto/NewChatMessageCountDto.java
+++ b/src/main/java/com/palbang/unsemawang/chat/dto/NewChatMessageCountDto.java
@@ -1,0 +1,16 @@
+package com.palbang.unsemawang.chat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NewChatMessageCountDto {
+	private int count;
+
+	public static NewChatMessageCountDto of(int count) {
+		return new NewChatMessageCountDto(count);
+	}
+}

--- a/src/main/java/com/palbang/unsemawang/chat/dto/NewChatMessageDto.java
+++ b/src/main/java/com/palbang/unsemawang/chat/dto/NewChatMessageDto.java
@@ -1,0 +1,16 @@
+package com.palbang.unsemawang.chat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NewChatMessageDto {
+	private String message;
+
+	public static NewChatMessageDto of(String message) {
+		return new NewChatMessageDto(message);
+	}
+}

--- a/src/main/java/com/palbang/unsemawang/chat/entity/ChatRoom.java
+++ b/src/main/java/com/palbang/unsemawang/chat/entity/ChatRoom.java
@@ -1,6 +1,9 @@
 package com.palbang.unsemawang.chat.entity;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 import com.palbang.unsemawang.common.entity.BaseEntity;
 import com.palbang.unsemawang.member.entity.Member;
@@ -19,7 +22,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Entity
 @Getter
 @Setter
@@ -77,5 +82,17 @@ public class ChatRoom extends BaseEntity {
 				.unreadCount(0)
 				.build();
 		}
+	}
+
+	public Optional<Member> getPartnerMember(String memberId) {
+		if (memberId == null) {
+			log.warn("getPartnerMember(String memberId) -> memberId가 null 임");
+			return Optional.empty();
+		}
+
+		return Stream.of(user1, user2)
+			.filter(Objects::nonNull) // null 인지 아닌지 확인
+			.filter(m -> !m.getId().equals(memberId)) // memberId와 일치하지 않는 user 찾기
+			.findFirst(); // 그 중 첫번째 객체 반환
 	}
 }


### PR DESCRIPTION
# 🚀 Pull Request

**채팅방 리스트를 보고 있을 경우 새로운 메세지 핸들링**

## #️⃣ 연관된 이슈

- #296 

## 📋 작업 내용

1. 새로운 메세지 내용, 새로운 메세지 개수를 전달하기 위한 DTO를 각각 만들었습니다

2. ChatMessageConsumer 클래스의 consumeMessage 메서드에 다음과 같은 로직을 추가하였습니다
- 채팅 상대가 채팅방 리스트를 보고 있을 경우 새로운 메세지를  알림
  채널: /topic/chat/{chatRoomId}/{memberId}/new-message
- 채팅 상대가 채팅방 리스트를 보고 잇을 경우 읽지 않은 메세지 개수를 알림
  채널: : /topic/chat/{chatRoomId}/{memberId}/new-message/count
- 추가로 메서드 전체를 감싸고 있던 catch문은 예외 로그를 알기가 어려워 임시 주석 처리 했습니다

## 🔧 변경된 코드 설명

- 상태 정보 변경 메세지가 전달된 경우 세션 헤더로부터 인증 정보를 가져오도록 수정하였습니다

## ✅ 테스트 여부

- [ ] 테스트 코드 실행 여부
- [ ] 서버 실행 여부
- [ ] 스웨거 테스트 여부

## 👽 비고

- 현재 안읽은 메세지 전달할 떄 잘 맞지 않는 오류가 있습니다..해결하면 바로 올릴게욥~
