### PR TITLE
[Fix]: fcm 관련 수정 및 webConfig 수정

### DIFF
--- a/src/main/java/com/palbang/unsemawang/config/WebConfig.java
+++ b/src/main/java/com/palbang/unsemawang/config/WebConfig.java
@@ -20,7 +20,7 @@ public class WebConfig implements WebMvcConfigurer {
 				"https://local.unsemawang.com",
 				"https://dev.unsemawang.com")
 
-			.allowedMethods("GET", "POST", "PUT", "DELETE")
+			.allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
 			.allowedHeaders("*")
 			.allowCredentials(true);
 	}

--- a/src/main/java/com/palbang/unsemawang/fcm/controller/FcmController.java
+++ b/src/main/java/com/palbang/unsemawang/fcm/controller/FcmController.java
@@ -67,7 +67,7 @@ public class FcmController {
 	@ApiResponse(responseCode = "400", description = "요청 형식이 잘못됨 (잘못된 토큰, 필드 누락, API 키 문제 등) -INVALID_ARGUMENT")
 	@ApiResponse(responseCode = "404", description = "FCM 토큰이 만료됨 (앱 삭제, 데이터 초기화, 오래 사용 안 한 경우) -UNREGISTERED")
 	@PostMapping("/send")
-	public String sendNotification(@AuthenticationPrincipal CustomOAuth2User auth, @RequestBody @Valid
+	public String sendMessage(@AuthenticationPrincipal CustomOAuth2User auth, @RequestBody @Valid
 		FcmNotificationRequest request) {
 
 		if (auth == null || auth.getId() == null) {
@@ -81,6 +81,31 @@ public class FcmController {
 			return "Error: " + e.getMessage();
 		}
 	}
+
+	//FCM 서버에 푸시 메시지 전송 요청
+	@Operation(
+		summary = "FCM 서버에 푸시 notification 전송 요청",
+		description = "FCM 서버에 푸시 메시지 전송을 요청 합니다."
+	)
+	@ApiResponse(responseCode = "200", description = "푸시 메시지 전송 요청 성공")
+	@ApiResponse(responseCode = "400", description = "요청 형식이 잘못됨 (잘못된 토큰, 필드 누락, API 키 문제 등) -INVALID_ARGUMENT")
+	@ApiResponse(responseCode = "404", description = "FCM 토큰이 만료됨 (앱 삭제, 데이터 초기화, 오래 사용 안 한 경우) -UNREGISTERED")
+	@PostMapping("/send-notification")
+	public String sendNotification(@AuthenticationPrincipal CustomOAuth2User auth, @RequestBody @Valid
+	FcmNotificationRequest request) {
+
+		if (auth == null || auth.getId() == null) {
+			throw new GeneralException(ResponseCode.EMPTY_TOKEN);
+		}
+
+		try {
+			return fcmService.sendPushNotification(request);
+		} catch (FirebaseMessagingException e) {
+			e.printStackTrace();
+			return "Error: " + e.getMessage();
+		}
+	}
+
 	@Operation(
 		summary = "FCM 토큰 조회",
 		description = "로그인한 회원의 FCM 토큰을 조회합니다."

--- a/src/main/java/com/palbang/unsemawang/fcm/service/FcmService.java
+++ b/src/main/java/com/palbang/unsemawang/fcm/service/FcmService.java
@@ -1,6 +1,7 @@
 package com.palbang.unsemawang.fcm.service;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -66,7 +67,25 @@ public class FcmService {
 		String body = request.getBody();
 		String url = request.getUrl();
 
-		// 푸시 알림 메시지 생성(우선 notification =>data로 변경할 수도 있음)
+		// FCM 메시지 요청 생성
+		Message message = Message.builder()
+			.setToken(token) // 특정 기기의 FCM 토큰
+			.putData("title", title)
+			.putData("body", body)
+			.putData("click_action", url)
+			.putData("image", "https://www.unsemawang.com/icon/icon_192.png")
+			.build();
+
+		// FCM 메시지 전송
+		return FirebaseMessaging.getInstance().send(message);
+	}
+
+	public String sendPushNotification(FcmNotificationRequest request) throws FirebaseMessagingException {
+		String token = request.getFcmToken();
+		String title = request.getTitle();
+		String body = request.getBody();
+		String url = request.getUrl();
+
 		Notification notification = Notification.builder()
 			.setTitle(title)
 			.setBody(body)
@@ -89,7 +108,7 @@ public class FcmService {
 			.orElseThrow(() -> new GeneralException(ResponseCode.NOT_EXIST_MEMBER_ID, "회원을 찾을 수 없습니다"));
 		List<String> fcmTokenList = fcmRepository.findByMemberIdAndIsActive(memberId);
 		if (fcmTokenList.isEmpty()) {
-			return null;
+			return Collections.emptyList();
 		}else{
 			return fcmTokenList;
 		}


### PR DESCRIPTION
# 🚀 Pull Request

1. 회원 fcm 토큰값 없을시 빈 배열 리턴하도록 수정
2. fcm 메세지 요청시 api 수정
3. webConfig 수정(allowedMethod -"PATCH", "OPTIONS" 추가)

## #️⃣ 연관된 이슈

- #272 

## 📋 작업 내용
1. 회원 fcm 토큰값 없을시 빈 배열 리턴하도록 수정
2. fcm 메세지 요청시 api 수정
3. webConfig 수정(allowedMethod -"PATCH", "OPTIONS" 추가)

## 🔧 변경된 코드 설명


## ✅ 테스트 여부

이 PR에 포함된 코드에 대해 테스트가 진행되었는지 작성해 주세요.
예시: 단위 테스트 작성 완료, 통합 테스트 완료, UI 테스트 진행 중
- [ ] 테스트 코드 실행 여부
- [x] 서버 실행 여부
- [x] 스웨거 테스트 여부

## 👽 비고

기타 알림 사항이 있으면 적어주세요.
