### PR TITLE
[Fix] 운세 공유 게시판 html 태그 등록 불가 검증 추가 #305

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,6 +110,9 @@ dependencies {
     //Firebase
     implementation 'com.google.firebase:firebase-admin:9.4.3'
 
+    // html -> text
+    implementation 'org.apache.commons:commons-text:1.10.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/palbang/unsemawang/community/dto/request/PostRegisterRequest.java
+++ b/src/main/java/com/palbang/unsemawang/community/dto/request/PostRegisterRequest.java
@@ -2,6 +2,7 @@ package com.palbang.unsemawang.community.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.palbang.unsemawang.community.constant.CommunityCategory;
+import com.palbang.unsemawang.community.validation.NoHtml;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -23,11 +24,12 @@ public class PostRegisterRequest {
 
 	@JsonIgnore
 	private String memberId;
-
+	
 	@NotBlank(message = "제목을 입력해 주세요")
 	@Size(min = 1, max = 100, message = "제목은 100자 이내여야 합니다")
 	private String title;
 
+	@NoHtml
 	@NotBlank(message = "내용을 입력해 주세요")
 	@Size(min = 1, max = 10000, message = "내용은 10,000자 이내여야 합니다")
 	private String content;

--- a/src/main/java/com/palbang/unsemawang/community/service/CommentService.java
+++ b/src/main/java/com/palbang/unsemawang/community/service/CommentService.java
@@ -118,7 +118,7 @@ public class CommentService {
 				.map(AnonymousMapping::getAnonymousName)
 				.orElse("알 수 없음"); // 매핑이 없는 경우 기본값
 		} else {
-			// 자유 게시판일 경우 사용자의 닉네임 반환
+			// 사용자의 닉네임 반환
 			return comment.getMember().getNickname();
 		}
 	}
@@ -127,11 +127,10 @@ public class CommentService {
 		if (category == CommunityCategory.ANONYMOUS_BOARD) {
 			// 익명 게시판: 고정된 익명 이미지 반환
 			return fileService.getAnonymousProfileImgUrl();
-		} else if (category == CommunityCategory.FREE_BOARD) {
-			// 자유 게시판: 사용자의 프로필 이미지 반환 (fileService 활용)
+		} else {
+			// 사용자의 프로필 이미지 반환 (fileService 활용)
 			return fileService.getProfileImgUrl(comment.getMember().getId());
 		}
-		throw new GeneralException(ResponseCode.ERROR_SEARCH);
 	}
 
 	public void registerComment(Long postId, CommentRegisterRequest request, String memberId) {

--- a/src/main/java/com/palbang/unsemawang/community/service/CommentService.java
+++ b/src/main/java/com/palbang/unsemawang/community/service/CommentService.java
@@ -117,11 +117,10 @@ public class CommentService {
 					comment.getMember().getId())
 				.map(AnonymousMapping::getAnonymousName)
 				.orElse("알 수 없음"); // 매핑이 없는 경우 기본값
-		} else if (category == CommunityCategory.FREE_BOARD) {
+		} else {
 			// 자유 게시판일 경우 사용자의 닉네임 반환
 			return comment.getMember().getNickname();
 		}
-		throw new GeneralException(ResponseCode.INVALID_CATEGORY); // 유효하지 않은 카테고리 처리
 	}
 
 	private String resolveProfileImageForReadResponse(Comment comment, CommunityCategory category) {

--- a/src/main/java/com/palbang/unsemawang/community/validation/NoHtml.java
+++ b/src/main/java/com/palbang/unsemawang/community/validation/NoHtml.java
@@ -1,0 +1,22 @@
+package com.palbang.unsemawang.community.validation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Documented
+@Constraint(validatedBy = NoHtmlValidator.class)
+@Target({ElementType.FIELD, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NoHtml {
+	String message() default "HTML 태그를 포함할 수 없습니다.";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/palbang/unsemawang/community/validation/NoHtmlValidator.java
+++ b/src/main/java/com/palbang/unsemawang/community/validation/NoHtmlValidator.java
@@ -1,0 +1,35 @@
+package com.palbang.unsemawang.community.validation;
+
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringEscapeUtils;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+/**
+ * HTML 태그 필터링을 위한 커스텀 검증기
+ * <h3>, <p> 태그만 허용하고, 나머지 모든 html 태그를 차단
+ */
+public class NoHtmlValidator implements ConstraintValidator<NoHtml, String> {
+	private static final Pattern HTML_TAG_PATTERN = Pattern.compile("<(?!/?(h3|p)\\b)[^>]+>");
+
+	/**
+	 *
+	 * @param value 검증할 문자열
+	 * @param context
+	 * @return 유효하면 true, html 태그 포함 시 false
+	 */
+	@Override
+	public boolean isValid(String value, ConstraintValidatorContext context) {
+		if (value == null) {
+			return true; // null 값은 검증하지 않음
+		}
+
+		// html 엔티티를 일반 텍스트로 변환
+		String unescaped = StringEscapeUtils.unescapeHtml4(value);
+
+		// 허용되지 않은 html 태그가 포함되어 있으면 false 반환
+		return !HTML_TAG_PATTERN.matcher(unescaped).find();
+	}
+}


### PR DESCRIPTION
# 🚀 Pull Request
- 운세 공유 게시판 html 태그 등록 불가 검증 추가
- 운세 공유 게시판일 때 댓글 조회 가능하게 수정

## #️⃣ 연관된 이슈
- #305 

## 📋 작업 내용


## 🔧 변경된 코드 설명
- build.gradle 의존성 추가
- 익명 게시판과 자유 게시판을 if - else if로 분기 처리했는데 if-else로 변경
- html 검증 애너테이션 추가 ( h3, p 태그는 예외)

## ✅ 테스트 여부
- [x] 테스트 코드 실행 여부
- [x] 서버 실행 여부
- [x] 스웨거 테스트 여부

## 👽 비고

기타 알림 사항이 있으면 적어주세요.
