### PR TITLE
[Fix] 채팅방 목록 성별 수정

### DIFF
--- a/src/main/java/com/palbang/unsemawang/chat/dto/ChatRoomDto.java
+++ b/src/main/java/com/palbang/unsemawang/chat/dto/ChatRoomDto.java
@@ -30,19 +30,18 @@ public class ChatRoomDto {
 	@Schema(required = true)
 	private LocalDateTime lastChatTime;
 	@Schema(required = true)
-	private String sex;
+	private char sex;
 	@Schema(required = true)
 	private String five;
 	@Schema(required = true)
 	private int unreadCount;
 
 	public static ChatRoomDto fromEntity(ChatRoom chatRoom, ChatMessage lastMessage, Member targetUser,
-		String fiveElement, int unreadCount, String profileImageUrl) {
+		String fiveElement, char sex, int unreadCount, String profileImageUrl) {
 
 		// targetUser의 정보가 없는 경우 기본값 설정
 		String userId = (targetUser != null) ? targetUser.getId() : "unknown";
 		String nickname = (targetUser != null) ? targetUser.getNickname() : "알 수 없음";
-		char gender = (targetUser != null) ? targetUser.getGender() : 'N';
 
 		LocalDateTime lastMessageTime = lastMessage != null ? lastMessage.getTimestamp() : chatRoom.getCreatedAt();
 		boolean isReadOnly = (chatRoom.getUser1() == null || chatRoom.getUser2() == null);
@@ -54,7 +53,7 @@ public class ChatRoomDto {
 			.profileImageUrl(profileImageUrl) // ChatRoomService에서 조회한 프로필 이미지 사용
 			.lastChat(lastMessage != null ? lastMessage.getContent() : "")
 			.lastChatTime(lastMessageTime)
-			.sex(gender == 'M' ? "남" : "여")
+			.sex(sex)
 			.five(fiveElement)
 			.unreadCount(unreadCount)
 			.build();

--- a/src/main/java/com/palbang/unsemawang/chat/service/ChatRoomService.java
+++ b/src/main/java/com/palbang/unsemawang/chat/service/ChatRoomService.java
@@ -22,6 +22,7 @@ import com.palbang.unsemawang.chemistry.constant.FiveElements;
 import com.palbang.unsemawang.common.constants.ResponseCode;
 import com.palbang.unsemawang.common.exception.GeneralException;
 import com.palbang.unsemawang.common.util.file.service.FileService;
+import com.palbang.unsemawang.fortune.entity.FortuneUserInfo;
 import com.palbang.unsemawang.fortune.repository.FortuneUserInfoRepository;
 import com.palbang.unsemawang.member.entity.Member;
 import com.palbang.unsemawang.member.repository.MemberRepository;
@@ -61,9 +62,14 @@ public class ChatRoomService {
 		Member targetUser = memberRepository.findById(receiverId)
 			.orElseThrow(() -> new GeneralException(ResponseCode.NOT_EXIST_MEMBER_ID));
 
+		FortuneUserInfo fortuneUserInfo = fortuneUserInfoRepository.findByMemberIdRelationIdIsOne(receiverId)
+			.orElseThrow(() -> new GeneralException(ResponseCode.ERROR_SEARCH));
+
+		char sex = fortuneUserInfo.getSex();
+
 		String profileImageUrl = fileService.getProfileImgUrl(targetUser.getId());
 
-		return ChatRoomDto.fromEntity(chatRoom, null, targetUser, null, 0, profileImageUrl);
+		return ChatRoomDto.fromEntity(chatRoom, null, targetUser, null, sex, 0, profileImageUrl);
 	}
 
 	/**
@@ -93,12 +99,17 @@ public class ChatRoomService {
 
 				String profileImageUrl = fileService.getProfileImgUrl(targetUser.getId());
 
+				FortuneUserInfo fortuneUserInfo = fortuneUserInfoRepository.findByMemberIdRelationIdIsOne(
+						targetUser.getId())
+					.orElseThrow(() -> new GeneralException(ResponseCode.ERROR_SEARCH));
+				char sex = fortuneUserInfo.getSex();
+
 				int unreadCount = chatMessageRepository.countByChatRoomAndSenderIdNotAndStatus(
 					chatRoom, userId, MessageStatus.RECEIVED);
 
 				String fiveElement = getUserFiveElement(targetUser.getId());
 
-				return ChatRoomDto.fromEntity(chatRoom, lastMessage, targetUser, fiveElement, unreadCount,
+				return ChatRoomDto.fromEntity(chatRoom, lastMessage, targetUser, fiveElement, sex, unreadCount,
 					profileImageUrl);
 			}).collect(Collectors.toList());
 	}


### PR DESCRIPTION
# 🚀 Pull Request

[Fix] 채팅방 목록 성별 수정

## #️⃣ 연관된 이슈

#318

## 📋 작업 내용

1. 채팅방 목록 조회 시 성별이 모두 '여'로 나오던 버그 수정

## 🔧 변경된 코드 설명

```java
// 채팅방 아이디와 회원 아이디로 상대 회원 객체 생성
Member targetUser = getTargetUser(chatRoom, userId)
					.orElseThrow(() -> new GeneralException(ResponseCode.NOT_EXIST_MEMBER_ID));

// 상대 회원 아이디로 사주 정보 객체 생성 후 성별 조회
FortuneUserInfo fortuneUserInfo = fortuneUserInfoRepository.findByMemberIdRelationIdIsOne(
						targetUser.getId())
					.orElseThrow(() -> new GeneralException(ResponseCode.ERROR_SEARCH));
				char sex = fortuneUserInfo.getSex();
```

## ✅ 테스트 여부

- [ ] 테스트 코드 실행 여부
- [x] 서버 실행 여부
- [x] 스웨거 테스트 여부

## 👽 비고

기타 알림 사항이 있으면 적어주세요.
