### PR TITLE
[Fix] 새로운 메세지 전달 방식 수정 #322

### DIFF
--- a/src/main/java/com/palbang/unsemawang/chat/service/ChatMessageConsumer.java
+++ b/src/main/java/com/palbang/unsemawang/chat/service/ChatMessageConsumer.java
@@ -45,7 +45,6 @@ public class ChatMessageConsumer {
 	@RabbitListener(queues = "chat.queue")
 	@Transactional // 트랜잭션 적용
 	public void consumeMessage(String messageJson) throws JsonProcessingException {
-		// try {
 		log.info("Received message from RabbitMQ: {}", messageJson);
 		ChatMessageDto chatMessageDto = objectMapper.readValue(messageJson, ChatMessageDto.class);
 
@@ -57,21 +56,9 @@ public class ChatMessageConsumer {
 			.orElseThrow(() -> new GeneralException(ResponseCode.RESOURCE_NOT_FOUND,
 				"채팅방을 찾을 수 없습니다. chatRoomId=" + chatMessageDto.getChatRoomId()));
 
-		//		ChatMessage chatMessage = ChatMessage.builder()
-		//			.chatRoom(chatRoom)
-		//			.sender(sender)
-		//			.content(chatMessageDto.getContent())
-		//			.status(MessageStatus.RECEIVED)
-		//			.timestamp(LocalDateTime.ofInstant(Instant.ofEpochMilli(chatMessageDto.getTimestamp()),
-		//				ZoneId.systemDefault()))
-		//			.build();
-
-		//		chatMessageRepository.save(chatMessage);
-
 		Member chatPartner = chatRoom.getPartnerMember(sender.getId())
 			.orElseThrow(() -> new GeneralException(ResponseCode.DEFAULT_BAD_REQUEST));
 
-		//		ChatMessageDto responseMessage = convertToDto(chatMessage);
 		messagingTemplate.convertAndSend("/topic/chat/" + chatRoom.getId(), chatMessageDto);
 		log.info("Forwarded WebSocket message: {}", chatMessageDto);
 
@@ -88,10 +75,6 @@ public class ChatMessageConsumer {
 			messagingTemplate.convertAndSend(destination + "/count", NewChatMessageCountDto.of(count));
 		}
 
-		// } catch (Exception e) {
-		// 	log.error("메시지 처리 실패: {}", e.getMessage(), e);
-		// 	throw new GeneralException(ResponseCode.DEFAULT_INTERNAL_SERVER_ERROR, "채팅 메시지 처리 중 예상치 못한 오류가 발생했습니다.");
-		// }
 	}
 
 	// Lazy Loading 해결 후 DTO 변환


### PR DESCRIPTION
# 🚀 Pull Request

**새로운 메세지 전달 방식 수정 **

## #️⃣ 연관된 이슈

- Closed #322 

## 📋 작업 내용

- 새로운 메세지를 처리할 때 상대방의 활동 상태 상관 없이 무조건 new-message 채널을 구독한 클라이언트에게 새로운 메세지 내용과 안본 메세지 수를 다 보내도록 수정

## 🔧 변경된 코드 설명

.

## ✅ 테스트 여부

- [x] 테스트 코드 실행 여부
- [x] 서버 실행 여부
- [x] 스웨거 테스트 여부

## 👽 비고

기타 알림 사항이 있으면 적어주세요.
