### PR TITLE
[Fix] 채팅방 생성 로직 수정

### DIFF
--- a/src/main/java/com/palbang/unsemawang/chat/entity/ChatRoom.java
+++ b/src/main/java/com/palbang/unsemawang/chat/entity/ChatRoom.java
@@ -47,9 +47,11 @@ public class ChatRoom extends BaseEntity {
 	private Member user2;  // 큰 ID를 가진 사용자
 
 	@Column(nullable = false)
+	@Builder.Default
 	private boolean user1Out = false;
 
 	@Column(nullable = false)
+	@Builder.Default
 	private boolean user2Out = false;
 
 	@Column(nullable = false)

--- a/src/main/java/com/palbang/unsemawang/chat/service/ChatRoomService.java
+++ b/src/main/java/com/palbang/unsemawang/chat/service/ChatRoomService.java
@@ -48,16 +48,14 @@ public class ChatRoomService {
 	 */
 	@Transactional
 	public ChatRoomDto createOrGetChatRoom(String senderId, String receiverId) {
-		ChatRoom chatRoom = chatRoomRepository.findByUsers(senderId, receiverId)
-			.orElseGet(() -> {
-				Member sender = memberRepository.findById(senderId)
-					.orElseThrow(() -> new GeneralException(ResponseCode.NOT_EXIST_MEMBER_ID));
-				Member receiver = memberRepository.findById(receiverId)
-					.orElseThrow(() -> new GeneralException(ResponseCode.NOT_EXIST_MEMBER_ID));
 
-				ChatRoom newChatRoom = ChatRoom.createSortedChatRoom(sender, receiver);
-				return chatRoomRepository.save(newChatRoom);
-			});
+		Member sender = memberRepository.findById(senderId)
+			.orElseThrow(() -> new GeneralException(ResponseCode.NOT_EXIST_MEMBER_ID));
+		Member receiver = memberRepository.findById(receiverId)
+			.orElseThrow(() -> new GeneralException(ResponseCode.NOT_EXIST_MEMBER_ID));
+
+		ChatRoom chatRoom = ChatRoom.createSortedChatRoom(sender, receiver);
+		chatRoomRepository.save(chatRoom);
 
 		Member targetUser = memberRepository.findById(receiverId)
 			.orElseThrow(() -> new GeneralException(ResponseCode.NOT_EXIST_MEMBER_ID));


### PR DESCRIPTION
# 🚀 Pull Request

[Fix] 채팅방 생성 로직 수정

## #️⃣ 연관된 이슈

#311 

## 📋 작업 내용

1. `createOrGetChatRoom` 메서드로 채팅방 생성 시 기존 채팅방이 존재하는지 확인하고 생성하는 로직 삭제

## 🔧 변경된 코드 설명

 - 채팅방 중복 생성이 가능합니다

## ✅ 테스트 여부

- [ ] 테스트 코드 실행 여부
- [x] 서버 실행 여부
- [x] 스웨거 테스트 여부

## 👽 비고

기타 알림 사항이 있으면 적어주세요.
