### PR TITLE
[Feature] 마지막 활동 시간 갱신 스케줄러 적용 #303

### DIFF
--- a/src/main/java/com/palbang/unsemawang/activity/entity/ActiveMember.java
+++ b/src/main/java/com/palbang/unsemawang/activity/entity/ActiveMember.java
@@ -1,5 +1,6 @@
 package com.palbang.unsemawang.activity.entity;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 
 import org.springframework.data.annotation.Id;
@@ -19,8 +20,8 @@ import lombok.ToString;
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@RedisHash(value = "activity_member")
-public class ActiveMember {
+@RedisHash(value = "activity_member", timeToLive = 10800)
+public class ActiveMember implements Serializable {
 	@Id
 	private String memberId;
 
@@ -29,6 +30,13 @@ public class ActiveMember {
 	private Long chatRoomId;
 
 	@Builder.Default
+	private boolean isSaved = false;
+
+	@Builder.Default
 	private LocalDateTime lastActiveAt = LocalDateTime.now();
+
+	public void markAsSaved() {
+		this.isSaved = true;
+	}
 
 }

--- a/src/main/java/com/palbang/unsemawang/activity/service/ActiveMemberService.java
+++ b/src/main/java/com/palbang/unsemawang/activity/service/ActiveMemberService.java
@@ -2,6 +2,7 @@ package com.palbang.unsemawang.activity.service;
 
 import java.util.List;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import com.palbang.unsemawang.activity.constant.ActiveStatus;
@@ -33,19 +34,19 @@ public class ActiveMemberService {
 		return (List<ActiveMember>)activeMemberRepository.findAll();
 	}
 
+	@Cacheable(value = "activity_member", key = "#memberId")
 	public ActiveMember findActiveMemberById(String memberId) {
 
 		Member member = memberRepository.findById(memberId).orElseThrow(
 			() -> new GeneralException(ResponseCode.NOT_EXIST_UNIQUE_NO)
 		);
 
-		ActiveMember activeMemberEntity = activeMemberRepository.findById(member.getId())
-			.orElse(ActiveMember.builder()
-				.memberId(member.getId())
-				.status(ActiveStatus.INACTIVE)
-				.lastActiveAt(member.getLastActivityAt())
-				.build()
-			);
+		ActiveMember activeMemberEntity = ActiveMember.builder()
+			.memberId(member.getId())
+			.status(ActiveStatus.INACTIVE)
+			.lastActiveAt(member.getLastActivityAt())
+			.build();
 		return activeMemberEntity;
 	}
+
 }

--- a/src/main/java/com/palbang/unsemawang/config/CacheConfig.java
+++ b/src/main/java/com/palbang/unsemawang/config/CacheConfig.java
@@ -1,0 +1,9 @@
+package com.palbang.unsemawang.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Configuration;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+}

--- a/src/main/java/com/palbang/unsemawang/config/SchedulerConfig.java
+++ b/src/main/java/com/palbang/unsemawang/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package com.palbang.unsemawang.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@EnableScheduling
+@Configuration
+public class SchedulerConfig {
+}

--- a/src/main/java/com/palbang/unsemawang/member/entity/Member.java
+++ b/src/main/java/com/palbang/unsemawang/member/entity/Member.java
@@ -91,6 +91,9 @@ public class Member extends BaseEntity {
 
 	private Boolean isTermsAgreed; // 약관 동의 true/false
 
+	@Column(name = "is_match_agreed")
+	private Boolean isMatchAgreed; // 매칭 동의 true/false
+
 	@OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Favorite> favorites; // 사용자가 찜한 목록
 
@@ -125,10 +128,15 @@ public class Member extends BaseEntity {
 
 	public void updateExtraInfo(SignupExtraInfoRequest signupExtraInfoDto) {
 		this.nickname = signupExtraInfoDto.getNickname();
+		this.isMatchAgreed = signupExtraInfoDto.isMatchAgreed();
 		this.changedAt = LocalDateTime.now();
 	}
 
 	public void updateLastActivityAt() {
 		this.lastActivityAt = LocalDateTime.now();
+	}
+
+	public void updateLastActivityAt(LocalDateTime lastActivityAt) {
+		this.lastActivityAt = lastActivityAt;
 	}
 }

--- a/src/main/java/com/palbang/unsemawang/member/service/MemberActiveScheduler.java
+++ b/src/main/java/com/palbang/unsemawang/member/service/MemberActiveScheduler.java
@@ -1,0 +1,39 @@
+package com.palbang.unsemawang.member.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.palbang.unsemawang.activity.entity.ActiveMember;
+import com.palbang.unsemawang.activity.repository.ActiveMemberRedisRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MemberActiveScheduler {
+
+	private final MemberActivityService memberActivityService;
+	private final ActiveMemberRedisRepository activeMemberRedisRepository;
+
+	/**
+	 * 5분마다 마지막 활동 일시 갱신
+	 */
+	@Scheduled(cron = "0 */5 * * * *") // 5분마다 실행
+	protected void updateLastActivitySchedule() {
+
+		List<ActiveMember> activeMembers = (ArrayList<ActiveMember>)activeMemberRedisRepository.findAll();
+
+		activeMembers.stream()
+			.filter((cache) -> !cache.isSaved()) // 저장되지 않은 정보만 업데이트
+			.forEach(cache -> {
+				memberActivityService.updateLastActivityTime(cache.getMemberId(), cache.getLastActiveAt());
+
+				// 저장됨 표시
+				cache.markAsSaved();
+				activeMemberRedisRepository.save(cache);
+			});
+	}
+}

--- a/src/main/java/com/palbang/unsemawang/member/service/MemberActivityService.java
+++ b/src/main/java/com/palbang/unsemawang/member/service/MemberActivityService.java
@@ -12,7 +12,9 @@ import com.palbang.unsemawang.member.entity.Member;
 import com.palbang.unsemawang.member.repository.MemberRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MemberActivityService {
@@ -32,5 +34,24 @@ public class MemberActivityService {
 	@Transactional(readOnly = true)
 	public List<Member> findRecentActiveMembersAfter(LocalDateTime asOfDateTime) {
 		return memberRepository.findAllByLastActivityAtAfter(asOfDateTime);
+	}
+
+	/**
+	 * member JPA 엔티티에 마지막 활동 시간 갱신
+	 * @param memberId
+	 * @param LastActivityTime
+	 */
+	@Transactional(rollbackFor = Exception.class)
+	public void updateLastActivityTime(String memberId, LocalDateTime LastActivityTime) {
+		Member member = memberRepository.findById(memberId)
+			.orElse(null);
+
+		if (member == null) {
+			log.warn("유효하지 않은 회원 ID의 마지막 활동 시간 갱신 시도가 이루어졌습니다");
+			return;
+		}
+
+		member.updateLastActivityAt(LastActivityTime);
+
 	}
 }


### PR DESCRIPTION
# 🚀 Pull Request

**마지막 활동 시간 갱신 스케줄러 적용 #**

## #️⃣ 연관된 이슈

- Closed #303 

## 📋 작업 내용

- 특정 회원의 활동 상태를 조회할 때 @Cacheable 어노테이션을 이용해 자동으로 레디스에서 읽어오도록 하고, 조회 결과가 없을 경우 DB에서 읽어와 반환하도록 수정하였습니다
- 5분마다 레디스에 저장된 회원 활동 상태를 읽어 새로 업데이트된 경우 DB에 마지막 활동 시간을 갱신하도록 스케줄러 메서드를 추가했습니다

## 🔧 변경된 코드 설명

- 활동 상태 레디스 엔티티에 TTL(Time To Live) 시간을 3시간으로 설정하고,
- DB에 저장됐는지 구분하기 위해 isSaved 필드를 추가했습니다

## ✅ 테스트 여부

- [ ] 테스트 코드 실행 여부
- [x] 서버 실행 여부
- [ ] 스웨거 테스트 여부

## 👽 비고

기타 알림 사항이 있으면 적어주세요.
