### PR TITLE
[Fix] 메시지 안보내지는 오류 수정

### DIFF
--- a/src/main/java/com/palbang/unsemawang/config/FirebaseConfig.java
+++ b/src/main/java/com/palbang/unsemawang/config/FirebaseConfig.java
@@ -5,6 +5,9 @@ import java.io.IOException;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
+
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.apache.v2.ApacheHttpTransport;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
@@ -21,6 +24,8 @@ public class FirebaseConfig {
 	@PostConstruct
 	public FirebaseApp initializeFcm() throws IOException {
 		String credentialsPath;
+		// HTTP/1.1을 사용하도록 NetHttpTransport 적용
+		HttpTransport httpTransport = new ApacheHttpTransport();
 
 		// 환경 변수 GOOGLE_APPLICATION_CREDENTIALS 확인
 		String envVar = System.getenv("GOOGLE_APPLICATION_CREDENTIALS");
@@ -47,6 +52,7 @@ public class FirebaseConfig {
 		// Firebase 옵션 설정
 		FirebaseOptions options = FirebaseOptions.builder()
 			.setCredentials(GoogleCredentials.fromStream(serviceAccount))
+			.setHttpTransport(httpTransport)
 			.build();
 
 		if (FirebaseApp.getApps().isEmpty()) {


### PR DESCRIPTION
# 🚀 Pull Request

fcmCofing 수정

## #️⃣ 연관된 이슈

- #330 

## 📋 작업 내용

fcm 메시지 요청 보낼시 자주 오류(Caused by: org.apache.hc.core5.http.ProtocolException: Header 'Host: fcm.googleapis.com' is illegal for HTTP/2 messages)가 발생하였음
HTTP/2 => HTTP/1.1 // HTTP/1.1을 사용하도록 NetHttpTransport 적용

## 🔧 변경된 코드 설명

주요 변경된 코드나 함수, 클래스, 모듈에 대해 설명해 주세요. 변경 사항이 중요한 부분이라면 코드와 함께 설명을 추가해주세요.

## ✅ 테스트 여부

이 PR에 포함된 코드에 대해 테스트가 진행되었는지 작성해 주세요.
예시: 단위 테스트 작성 완료, 통합 테스트 완료, UI 테스트 진행 중
- [ ] 테스트 코드 실행 여부
- [ ] 서버 실행 여부
- [ ] 스웨거 테스트 여부

## 👽 비고

기타 알림 사항이 있으면 적어주세요.
